### PR TITLE
Wrap auto-trader meta lines instead of clipping them

### DIFF
--- a/frontend/src/components/BuySellConfig.scss
+++ b/frontend/src/components/BuySellConfig.scss
@@ -129,7 +129,11 @@
 }
 
 .buy-sell-config__meta {
-  white-space: nowrap;
+  // These paragraphs hold generated prose of unbounded length (plan notes joined
+  // with " · ", ISO horizons, blocked ranges). nowrap forced them onto one line
+  // that the page's overflow-x: clip then cut off; wrap instead, breaking any
+  // token too wide for the column (long ISO timestamps on narrow screens).
+  overflow-wrap: break-word;
   font-variant-numeric: tabular-nums;
   opacity: 0.92;
   font-size: 0.85rem;


### PR DESCRIPTION
## Problem

In the Automatic trading panel, this plan-notes line runs off the right edge and gets clipped (the page uses `overflow-x: clip`, so there isn't even a scrollbar — the text just vanishes):

> Reserve already breached in the no-trade projection (forecast shortfall of 10.1 kWh·slots) — selling only where it doesn't worsen it · Horizon 2026-07-07T07:19:39.822Z → 2026-07-07T22:00:00.000Z (+18h reserve tail)

## Cause

`AutoTraderPanel.tsx` renders the plan notes into `.buy-sell-config__meta`:

```tsx
<p class="buy-sell-config__meta">{plan().notes.join(" · ")}</p>
```

…and that class had `white-space: nowrap`. The notes are generated prose of unbounded length (`planner.ts` joins a breached-reserve note with a `Horizon <ISO> → <ISO> (+Nh reserve tail)` line), so `nowrap` forced the whole thing onto one line that `overflow-x: clip` then cut off. The same class also backs the last-plan summary, blocked-ranges, and safety-guard lines — all equally unbounded — so `nowrap` was the wrong choice throughout, not just for this one note.

## Fix

Swap `white-space: nowrap` for `overflow-wrap: break-word` on `.buy-sell-config__meta`. The paragraph now wraps within its column, and any single token too wide to fit (a long ISO timestamp on a narrow screen) breaks rather than overflowing. `font-variant-numeric: tabular-nums` is kept for digit alignment.

CSS-only change; no wire shape or backend note text touched.

## Verification

- `yarn sass` compiles the stylesheet cleanly; the emitted rule is `overflow-wrap: break-word` with no `nowrap`.
- `yarn typecheck` passes from the repo root.
- Before/after repro (real container chain — `.buy-sell-page` `overflow-x: clip` → `.buy-sell-config__section` → `.buy-sell-config__meta`, narrowed to a phone-width column, exact overflowing string) confirms the line is clipped before and wraps after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)