### PR TITLE
Auto-trader: contiguous sell windows, guard that re-plans, veto-clear button

### DIFF
--- a/backend/src/autoTrading/autoTrader.ts
+++ b/backend/src/autoTrading/autoTrader.ts
@@ -544,6 +544,11 @@ async function runPlan(ctx: TraderCtx, options: RunPlanOptions): Promise<string>
  * feasible again (the old trim-only guard stranded those until someone clicked regenerate — see
  * the 2026-07-06 incident). User windows are never touched; an active window keeps running unless
  * it alone breaches the reserve, in which case it is stubbed to end now.
+ *
+ * Unlike the old in-lock trim, the shedding lands only when the re-plan's applyPlan finishes (a
+ * few seconds later, solar/consumption fetches included). That gap is acceptable because a
+ * projected breach concerns windows hours out, and even mid-gap the runtime's own
+ * only_sell_above_soc cutoff hard-stops selling regardless of what the schedule says.
  */
 async function runGuard(ctx: TraderCtx) {
   if (ctx.flags.planInFlight) {
@@ -664,7 +669,9 @@ async function runGuard(ctx: TraderCtx) {
 /**
  * End every currently-running owned sell window in a minute (stub instead of delete so the entry
  * stays visible as history). Used when the active window itself breaches the reserve — the
- * re-plan treats active windows as immutable and could not stop it.
+ * re-plan treats active windows as immutable and could not stop it. The follow-up re-plan then
+ * deliberately keeps the ≤60s remnant as a fixed "active" window: deleting it would erase the
+ * history, and nothing new can be scheduled into a minute that is already passing.
  */
 function stubActiveSellWindows(ctx: TraderCtx, now: number) {
   const activeSelling = activeOwnedEntries(ctx, now).selling;

--- a/backend/src/autoTrading/autoTrader.ts
+++ b/backend/src/autoTrading/autoTrader.ts
@@ -192,6 +192,10 @@ async function clearTradingVetoes(ctx: TraderCtx): Promise<string> {
   refreshStatus(ctx);
   if (!cleared) return "no blocked ranges to clear";
   const summary = await runPlan(ctx, { trigger: "veto-clear", waitForTomorrow: false });
+  if (summary === "plan already in progress") {
+    // That plan may have sampled the vetoes before the clear — be honest instead of claiming a re-plan
+    return `cleared ${cleared} blocked range(s); another plan is running — hit "Generate plan now" afterwards to re-plan the freed ranges`;
+  }
   return `cleared ${cleared} blocked range(s); ${summary}`;
 }
 
@@ -395,23 +399,20 @@ function applyPlan(
     // Entries (ours or the user's) whose window ended over a day ago are dead weight in the UI;
     // unparseable dates (NaN) are deliberately kept — deleting what we can't interpret is worse.
     const pruneBeforeMs = Date.now() - 24 * 3600 * 1000;
-    for (const [key, entry] of Object.entries(selling)) {
-      if (+new Date(entry.end_time) < pruneBeforeMs) delete selling[key];
-    }
-    for (const [key, entry] of Object.entries(buying)) {
-      if (+new Date(entry.end_time) < pruneBeforeMs) delete buying[key];
-    }
-    // An identical regeneration must be a no-op, not config churn
+    const prunedSelling = pickEntries(selling, (_, entry) => !(+new Date(entry.end_time) < pruneBeforeMs));
+    const prunedBuying = pickEntries(buying, (_, entry) => !(+new Date(entry.end_time) < pruneBeforeMs));
+    // An identical regeneration must be a no-op, not config churn (delete+re-add shuffles key
+    // order, so compare with sorted keys)
     if (
-      JSON.stringify(selling) === JSON.stringify(prev.scheduled_power_selling.schedule) &&
-      JSON.stringify(buying) === JSON.stringify(prev.scheduled_power_buying.schedule)
+      canonicalSchedule(prunedSelling) === canonicalSchedule(prev.scheduled_power_selling.schedule) &&
+      canonicalSchedule(prunedBuying) === canonicalSchedule(prev.scheduled_power_buying.schedule)
     ) {
       return prev;
     }
     return {
       ...prev,
-      scheduled_power_selling: { ...prev.scheduled_power_selling, schedule: selling },
-      scheduled_power_buying: { ...prev.scheduled_power_buying, schedule: buying },
+      scheduled_power_selling: { ...prev.scheduled_power_selling, schedule: prunedSelling },
+      scheduled_power_buying: { ...prev.scheduled_power_buying, schedule: prunedBuying },
     };
   });
   ctx.state.owned_entries = newOwned;
@@ -584,8 +585,17 @@ async function runGuard(ctx: TraderCtx) {
         return false;
       }
 
+      // Owned buys recharge the battery — projecting the sells without them would fabricate
+      // breaches (and could stub a perfectly safe active sell)
+      const ourBuyWindows = ownedEntriesAsWindows(ctx.state.owned_entries.buying, "charging_power").filter(
+        window => window.endMs > now
+      );
       const projectionWith = (windows: typeof ourWindows) =>
-        projectWithFixedWindows({ ...baseInput, fixedSells: [...baseInput.fixedSells, ...windows] });
+        projectWithFixedWindows({
+          ...baseInput,
+          fixedSells: [...baseInput.fixedSells, ...windows],
+          fixedBuys: [...baseInput.fixedBuys, ...ourBuyWindows],
+        });
 
       const projection = projectionWith(ourWindows);
       const tolerable = projectWithFixedWindows(baseInput).violationWh + 1000; // don't blame our windows for a forecast already under water
@@ -617,15 +627,24 @@ async function runGuard(ctx: TraderCtx) {
         keepActiveWindows: true,
         prices,
       });
-      if (summary.startsWith("error:")) {
+      if (summary === "plan already in progress") {
+        // Whatever plan slipped in re-plans from live conditions anyway; don't claim success here
+        ctx.state.guard = {
+          last_run_at: new Date().toISOString(),
+          last_action: "projected breach; another plan is running — re-checking next tick",
+        };
+      } else if (summary.startsWith("error:")) {
         // No planner available (e.g. solar forecast fetch died) but the reserve is in danger —
-        // shed all our future windows rather than keep selling into a projected breach.
+        // shed our future sells rather than keep selling into a projected breach. Owned buys are
+        // kept: they only add energy, i.e. help the reserve.
         await withScheduleLock(ctx, async () => {
-          applyPlan(ctx, [], [], activeOwnedEntries(ctx, Date.now()));
+          const keep = activeOwnedEntries(ctx, Date.now());
+          keep.buying = { ...ctx.state.owned_entries.buying };
+          applyPlan(ctx, [], [], keep);
         });
         ctx.state.guard = {
           last_run_at: new Date().toISOString(),
-          last_action: `re-plan failed (${summary}) — dropped all planner windows to protect the reserve`,
+          last_action: `re-plan failed (${summary}) — dropped planner sell windows to protect the reserve`,
         };
       } else {
         ctx.state.guard = {
@@ -648,11 +667,11 @@ async function runGuard(ctx: TraderCtx) {
  * re-plan treats active windows as immutable and could not stop it.
  */
 function stubActiveSellWindows(ctx: TraderCtx, now: number) {
+  const activeSelling = activeOwnedEntries(ctx, now).selling;
   const shortenedStubs: Record<string, { end_time: string; power_watts: number }> = {};
   ctx.setConfig(prev => {
     const selling = { ...prev.scheduled_power_selling.schedule };
-    for (const [key, owned] of Object.entries(ctx.state.owned_entries.selling)) {
-      if (+new Date(key) > now || +new Date(owned.end_time) <= now) continue;
+    for (const [key, owned] of Object.entries(activeSelling)) {
       if (selling[key] && entriesEqual(selling[key], owned, "power_watts")) {
         const stubEnd = new Date(now + 60_000).toISOString();
         selling[key] = { ...selling[key], end_time: stubEnd };
@@ -669,14 +688,29 @@ function stubActiveSellWindows(ctx: TraderCtx, now: number) {
 
 /** Owned entries whose window is executing right now (start ≤ now < end). */
 function activeOwnedEntries(ctx: TraderCtx, now: number): AutoTraderState["owned_entries"] {
-  const active: AutoTraderState["owned_entries"] = { selling: {}, buying: {} };
-  for (const [key, owned] of Object.entries(ctx.state.owned_entries.selling)) {
-    if (+new Date(key) <= now && +new Date(owned.end_time) > now) active.selling[key] = owned;
-  }
-  for (const [key, owned] of Object.entries(ctx.state.owned_entries.buying)) {
-    if (+new Date(key) <= now && +new Date(owned.end_time) > now) active.buying[key] = owned;
-  }
-  return active;
+  const isActive = (key: string, entry: { end_time: string }) =>
+    +new Date(key) <= now && +new Date(entry.end_time) > now;
+  return {
+    selling: pickEntries(ctx.state.owned_entries.selling, isActive),
+    buying: pickEntries(ctx.state.owned_entries.buying, isActive),
+  };
+}
+
+/** Object.fromEntries + filter over a schedule/ownership map, preserving the value type. */
+function pickEntries<EntryType extends { end_time: string }>(
+  entries: Record<string, EntryType>,
+  keep: (key: string, entry: EntryType) => boolean
+): Record<string, EntryType> {
+  return Object.fromEntries(Object.entries(entries).filter(([key, entry]) => keep(key, entry)));
+}
+
+/** Schedule serialized with sorted keys — insertion order must not defeat equality checks. */
+function canonicalSchedule(schedule: Record<string, { end_time: string }>): string {
+  return JSON.stringify(
+    Object.keys(schedule)
+      .sort()
+      .map(key => [key, schedule[key]])
+  );
 }
 
 /**

--- a/backend/src/autoTrading/autoTrader.ts
+++ b/backend/src/autoTrading/autoTrader.ts
@@ -115,7 +115,12 @@ export function useAutoTrader({ configSignal }: { configSignal: Awaited<ReturnTy
         const lastPlanMs = ctx.state.last_plan ? +new Date(ctx.state.last_plan.generated_at) : 0;
         if (Date.now() - lastPlanMs < 45 * 60_000) return; // fresh plan — nothing to improve yet
         const gainGate = untrack(config).automatic_trading.opportunistic_replan_min_gain_sek ?? 5;
-        void runPlan(ctx, "opportunistic", false, gainGate).then(result => {
+        void runPlan(ctx, {
+          trigger: "opportunistic",
+          waitForTomorrow: false,
+          gainGateSek: gainGate,
+          keepActiveWindows: true,
+        }).then(result => {
           if (result.startsWith("kept existing plan")) debugLog("Auto trader opportunistic:", result);
         });
       }, replanMinutes * 60_000);
@@ -165,8 +170,29 @@ export function useAutoTrader({ configSignal }: { configSignal: Awaited<ReturnTy
 
   return {
     autoTraderStatus: status,
-    triggerPlanNow: () => runPlan(ctx, "manual", false),
+    triggerPlanNow: () => runPlan(ctx, { trigger: "manual", waitForTomorrow: false }),
+    clearTradingVetoes: () => clearTradingVetoes(ctx),
   };
+}
+
+/**
+ * Forget every veto (time ranges blocked because the user deleted planner windows there) and
+ * immediately re-plan so the freed ranges get scheduled again. Exposed as a ws action for the
+ * frontend's "unblock" button.
+ */
+async function clearTradingVetoes(ctx: TraderCtx): Promise<string> {
+  const cleared = await withScheduleLock(ctx, async () => {
+    const count = ctx.state.vetoes.length;
+    if (count) {
+      ctx.state.vetoes = [];
+      await saveAutoTraderState(ctx.state);
+    }
+    return count;
+  });
+  refreshStatus(ctx);
+  if (!cleared) return "no blocked ranges to clear";
+  const summary = await runPlan(ctx, { trigger: "veto-clear", waitForTomorrow: false });
+  return `cleared ${cleared} blocked range(s); ${summary}`;
 }
 
 /**
@@ -366,6 +392,22 @@ function applyPlan(
       if (!buying[key]) buying[key] = entry;
       else if (!entriesEqual(buying[key], entry, "charging_power")) delete newOwned.buying[key];
     }
+    // Entries (ours or the user's) whose window ended over a day ago are dead weight in the UI;
+    // unparseable dates (NaN) are deliberately kept — deleting what we can't interpret is worse.
+    const pruneBeforeMs = Date.now() - 24 * 3600 * 1000;
+    for (const [key, entry] of Object.entries(selling)) {
+      if (+new Date(entry.end_time) < pruneBeforeMs) delete selling[key];
+    }
+    for (const [key, entry] of Object.entries(buying)) {
+      if (+new Date(entry.end_time) < pruneBeforeMs) delete buying[key];
+    }
+    // An identical regeneration must be a no-op, not config churn
+    if (
+      JSON.stringify(selling) === JSON.stringify(prev.scheduled_power_selling.schedule) &&
+      JSON.stringify(buying) === JSON.stringify(prev.scheduled_power_buying.schedule)
+    ) {
+      return prev;
+    }
     return {
       ...prev,
       scheduled_power_selling: { ...prev.scheduled_power_selling, schedule: selling },
@@ -375,24 +417,30 @@ function applyPlan(
   ctx.state.owned_entries = newOwned;
 }
 
-/**
- * @param onlyIfGainSek when set, the new plan only replaces the existing windows if its projected
- * revenue beats what the currently-written windows would earn by at least this much (used by the
- * opportunistic replan so a working plan isn't churned for pennies). In this mode currently-active
- * windows are also treated as fixed so an in-progress sell is never interrupted.
- */
-async function runPlan(
-  ctx: TraderCtx,
-  trigger: string,
-  waitForTomorrow: boolean,
-  onlyIfGainSek?: number
-): Promise<string> {
+type RunPlanOptions = {
+  trigger: string;
+  /** Wait (retrying) until tomorrow's day-ahead prices are published before planning */
+  waitForTomorrow: boolean;
+  /**
+   * When set, the new plan only replaces the existing windows if its projected revenue beats what
+   * the currently-written windows would earn by at least this much (used by the opportunistic
+   * replan so a working plan isn't churned for pennies).
+   */
+  gainGateSek?: number;
+  /** Treat currently-executing owned windows as fixed so an in-progress trade is never interrupted */
+  keepActiveWindows?: boolean;
+  /** Plan with these prices instead of fetching (the guard passes its own, possibly cached, fetch) */
+  prices?: FetchedPrices;
+};
+
+async function runPlan(ctx: TraderCtx, options: RunPlanOptions): Promise<string> {
+  const { trigger, waitForTomorrow, gainGateSek, keepActiveWindows } = options;
   if (ctx.flags.planInFlight) return "plan already in progress";
   ctx.flags.planInFlight = true;
   try {
     const tradingConfig = untrack(ctx.config).automatic_trading;
 
-    let prices = await fetchPrices(tradingConfig.price_area, trigger === "daily");
+    let prices = options.prices ?? (await fetchPrices(tradingConfig.price_area, trigger === "daily"));
     if (waitForTomorrow && !prices.coversTomorrow) {
       const retryMinutes = Math.max(2, tradingConfig.replan_retry_minutes);
       for (let attempt = 1; attempt <= 16 && !ctx.flags.aborted; attempt++) {
@@ -418,25 +466,18 @@ async function runPlan(
       const freshCfg = untrack(ctx.config);
       reconcileOwnership(ctx, freshCfg);
 
-      // During gated (opportunistic) replans, a window that is running right now must not be
-      // rewritten mid-sell — plan around it and keep it.
-      const now = Date.now();
-      const keepOwned: AutoTraderState["owned_entries"] = { selling: {}, buying: {} };
-      if (onlyIfGainSek !== undefined) {
-        for (const [key, owned] of Object.entries(ctx.state.owned_entries.selling)) {
-          if (+new Date(key) <= now && +new Date(owned.end_time) > now) keepOwned.selling[key] = owned;
-        }
-        for (const [key, owned] of Object.entries(ctx.state.owned_entries.buying)) {
-          if (+new Date(key) <= now && +new Date(owned.end_time) > now) keepOwned.buying[key] = owned;
-        }
-      }
+      // A window that is running right now must not be rewritten mid-sell — plan around it
+      // and keep it (opportunistic and guard replans; a full plan may reshape everything).
+      const keepOwned: AutoTraderState["owned_entries"] = keepActiveWindows
+        ? activeOwnedEntries(ctx, Date.now())
+        : { selling: {}, buying: {} };
 
       const input = await buildPlannerInput(ctx, freshCfg, prices, plannedSoc);
       input.fixedSells = [...input.fixedSells, ...ownedEntriesAsWindows(keepOwned.selling, "power_watts")];
       input.fixedBuys = [...input.fixedBuys, ...ownedEntriesAsWindows(keepOwned.buying, "charging_power")];
       const result = generatePlan(input);
 
-      if (onlyIfGainSek !== undefined) {
+      if (gainGateSek !== undefined) {
         // What would the windows currently in the config earn under the same live conditions?
         const existing = projectWithFixedWindows({
           ...input,
@@ -444,8 +485,8 @@ async function runPlan(
           fixedBuys: [...input.fixedBuys, ...ownedEntriesAsWindows(ctx.state.owned_entries.buying, "charging_power")],
         });
         const gain = result.projection.estimatedRevenueSek - existing.revenueSek;
-        if (gain < onlyIfGainSek) {
-          return `kept existing plan — replacement would gain ${gain.toFixed(1)} SEK (< ${onlyIfGainSek})`;
+        if (gain < gainGateSek) {
+          return `kept existing plan — replacement would gain ${gain.toFixed(1)} SEK (< ${gainGateSek})`;
         }
         logLog(`Auto trader: opportunistic replan beats current windows by ${gain.toFixed(1)} SEK — applying`);
       }
@@ -496,8 +537,12 @@ async function runPlan(
 }
 
 /**
- * Periodic safety check: with live SOC and fresh forecasts, would the remaining schedule
- * drag SOC below the reserve? If so, trim our windows (never the user's), cheapest first.
+ * Periodic safety check: with live SOC and fresh forecasts, would the remaining schedule drag SOC
+ * below the reserve? If so, re-plan the remaining horizon from live conditions instead of merely
+ * trimming: a fresh plan sheds exactly as much selling as needed AND re-adds windows that became
+ * feasible again (the old trim-only guard stranded those until someone clicked regenerate — see
+ * the 2026-07-06 incident). User windows are never touched; an active window keeps running unless
+ * it alone breaches the reserve, in which case it is stubbed to end now.
  */
 async function runGuard(ctx: TraderCtx) {
   if (ctx.flags.planInFlight) {
@@ -514,14 +559,16 @@ async function runGuard(ctx: TraderCtx) {
     const soc = untrack(ctx.averageSOC);
     if (soc === undefined) return;
     const priceArea = untrack(ctx.config).automatic_trading.price_area;
-    // For a trim decision slightly stale prices beat no guard run at all
+    // For a breach decision slightly stale prices beat no guard run at all
     const prices = (await fetchPrices(priceArea).catch(() => undefined)) ?? getCachedPrices(priceArea);
     if (!prices) {
       debugLog("Auto trader guard: prices unavailable (fetch failed, no cache) — skipping this run");
       return;
     }
     const guardSoc = soc;
-    await withScheduleLock(ctx, async () => {
+    // Phase 1, under the lock: detect a breach and immediately stop an active window that alone
+    // causes it. The re-plan itself runs outside the lock (runPlan takes the lock internally).
+    const breach = await withScheduleLock(ctx, async () => {
       // Re-read inside the lock — a plan may have rewritten the schedules while we awaited the
       // price fetch, and reconciling against a stale snapshot would spuriously veto its windows
       const cfg = untrack(ctx.config);
@@ -534,76 +581,59 @@ async function runGuard(ctx: TraderCtx) {
       );
       if (!ourWindows.length) {
         ctx.state.guard = { last_run_at: new Date().toISOString(), last_action: "nothing to guard" };
-        return;
+        return false;
       }
 
       const projectionWith = (windows: typeof ourWindows) =>
         projectWithFixedWindows({ ...baseInput, fixedSells: [...baseInput.fixedSells, ...windows] });
 
-      const kept = [...ourWindows];
-      let projection = projectionWith(kept);
+      const projection = projectionWith(ourWindows);
       const tolerable = projectWithFixedWindows(baseInput).violationWh + 1000; // don't blame our windows for a forecast already under water
-      let trimmed = 0;
-      while (projection.violationWh > tolerable && kept.length) {
-        // Sacrifice the least valuable window first (lowest avg spot per state notes, fallback: latest)
-        const windowValue = (window: (typeof kept)[number]) => {
-          const stateWindow = ctx.state.last_plan?.windows.find(
-            candidate => +new Date(candidate.start) === window.startMs && candidate.kind === "sell"
-          );
-          return stateWindow?.avg_spot ?? 0;
+      if (projection.violationWh <= tolerable) {
+        ctx.state.guard = {
+          last_run_at: new Date().toISOString(),
+          last_action: `ok (projected min SOC ${projection.minSocPercent}% @ ${projection.minSocAt})`,
         };
-        kept.sort((a, b) => windowValue(a) - windowValue(b));
-        const sacrificed = kept.shift()!;
-        trimmed++;
-        logLog(
-          "Auto trader guard: trimming sell window",
-          new Date(sacrificed.startMs).toISOString(),
-          "to protect reserve (projected min SOC",
-          projection.minSocPercent,
-          "% )"
-        );
-        projection = projectionWith(kept);
+        return false;
       }
 
-      if (trimmed) {
-        const keptKeys = new Set(kept.map(window => new Date(window.startMs).toISOString()));
-        const shortenedStubs: Record<string, { end_time: string; power_watts: number }> = {};
-        ctx.setConfig(prev => {
-          const selling = { ...prev.scheduled_power_selling.schedule };
-          for (const [key, owned] of Object.entries(ctx.state.owned_entries.selling)) {
-            if (keptKeys.has(key)) continue;
-            if (+new Date(owned.end_time) <= now) continue;
-            if (selling[key] && entriesEqual(selling[key], owned, "power_watts")) {
-              const startMs = +new Date(key);
-              if (startMs <= now) {
-                // Active window: end it now instead of deleting so history stays visible
-                const stubEnd = new Date(now + 60_000).toISOString();
-                selling[key] = { ...selling[key], end_time: stubEnd };
-                shortenedStubs[key] = { end_time: stubEnd, power_watts: Number(owned.power_watts) };
-              } else {
-                delete selling[key];
-              }
-            }
-          }
-          return { ...prev, scheduled_power_selling: { ...prev.scheduled_power_selling, schedule: selling } };
-        });
-        // Ownership: surviving windows, already-finished windows and the just-shortened stub stay ours
-        const nextOwned: typeof ctx.state.owned_entries.selling = { ...shortenedStubs };
-        for (const key of Object.keys(ctx.state.owned_entries.selling)) {
-          if (keptKeys.has(key) || +new Date(ctx.state.owned_entries.selling[key].end_time) <= now) {
-            nextOwned[key] = ctx.state.owned_entries.selling[key];
-          }
-        }
-        ctx.state.owned_entries.selling = nextOwned;
+      // The re-plan keeps active windows immutable, so it can't stop one that is itself the
+      // problem — that case is handled here, before planning
+      const activeWindows = ourWindows.filter(window => window.startMs <= now);
+      if (activeWindows.length && projectionWith(activeWindows).violationWh > tolerable) {
+        stubActiveSellWindows(ctx, now);
       }
-
       ctx.state.guard = {
         last_run_at: new Date().toISOString(),
-        last_action: trimmed
-          ? `trimmed ${trimmed} sell window(s), projected min SOC now ${projection.minSocPercent}%`
-          : `ok (projected min SOC ${projection.minSocPercent}% @ ${projection.minSocAt})`,
+        last_action: `projected reserve breach (min SOC ${projection.minSocPercent}% @ ${projection.minSocAt}) — re-planning`,
       };
+      return true;
     });
+
+    if (breach) {
+      const summary = await runPlan(ctx, {
+        trigger: "guard",
+        waitForTomorrow: false,
+        keepActiveWindows: true,
+        prices,
+      });
+      if (summary.startsWith("error:")) {
+        // No planner available (e.g. solar forecast fetch died) but the reserve is in danger —
+        // shed all our future windows rather than keep selling into a projected breach.
+        await withScheduleLock(ctx, async () => {
+          applyPlan(ctx, [], [], activeOwnedEntries(ctx, Date.now()));
+        });
+        ctx.state.guard = {
+          last_run_at: new Date().toISOString(),
+          last_action: `re-plan failed (${summary}) — dropped all planner windows to protect the reserve`,
+        };
+      } else {
+        ctx.state.guard = {
+          last_run_at: new Date().toISOString(),
+          last_action: `re-planned after projected breach — ${summary}`,
+        };
+      }
+    }
     await saveAutoTraderState(ctx.state);
     refreshStatus(ctx);
     debugLog(`Auto trader guard: done in ${Date.now() - startedAt}ms — ${ctx.state.guard?.last_action}`);
@@ -613,12 +643,49 @@ async function runGuard(ctx: TraderCtx) {
 }
 
 /**
+ * End every currently-running owned sell window in a minute (stub instead of delete so the entry
+ * stays visible as history). Used when the active window itself breaches the reserve — the
+ * re-plan treats active windows as immutable and could not stop it.
+ */
+function stubActiveSellWindows(ctx: TraderCtx, now: number) {
+  const shortenedStubs: Record<string, { end_time: string; power_watts: number }> = {};
+  ctx.setConfig(prev => {
+    const selling = { ...prev.scheduled_power_selling.schedule };
+    for (const [key, owned] of Object.entries(ctx.state.owned_entries.selling)) {
+      if (+new Date(key) > now || +new Date(owned.end_time) <= now) continue;
+      if (selling[key] && entriesEqual(selling[key], owned, "power_watts")) {
+        const stubEnd = new Date(now + 60_000).toISOString();
+        selling[key] = { ...selling[key], end_time: stubEnd };
+        shortenedStubs[key] = { end_time: stubEnd, power_watts: Number(owned.power_watts) };
+      }
+    }
+    return { ...prev, scheduled_power_selling: { ...prev.scheduled_power_selling, schedule: selling } };
+  });
+  for (const [key, stub] of Object.entries(shortenedStubs)) {
+    ctx.state.owned_entries.selling[key] = stub;
+    logLog("Auto trader guard: ending active sell window", key, "now to protect the reserve");
+  }
+}
+
+/** Owned entries whose window is executing right now (start ≤ now < end). */
+function activeOwnedEntries(ctx: TraderCtx, now: number): AutoTraderState["owned_entries"] {
+  const active: AutoTraderState["owned_entries"] = { selling: {}, buying: {} };
+  for (const [key, owned] of Object.entries(ctx.state.owned_entries.selling)) {
+    if (+new Date(key) <= now && +new Date(owned.end_time) > now) active.selling[key] = owned;
+  }
+  for (const [key, owned] of Object.entries(ctx.state.owned_entries.buying)) {
+    if (+new Date(key) <= now && +new Date(owned.end_time) > now) active.buying[key] = owned;
+  }
+  return active;
+}
+
+/**
  * runPlan + retry: transient failures (undici connect timeouts while the pi is CPU-pegged,
  * upstream hiccups) reschedule another attempt instead of silently waiting for the next day.
  */
 async function runPlanWithRecovery(ctx: TraderCtx, trigger: string, waitForTomorrow: boolean): Promise<string> {
   clearTimeout(ctx.timers.recovery);
-  const result = await runPlan(ctx, trigger, waitForTomorrow);
+  const result = await runPlan(ctx, { trigger, waitForTomorrow });
   if (result.startsWith("error:") && !ctx.flags.aborted) {
     ctx.flags.consecutiveFailures++;
     const maxAttempts = 8;

--- a/backend/src/autoTrading/planPreview.ts
+++ b/backend/src/autoTrading/planPreview.ts
@@ -10,6 +10,7 @@ import { promises as fs_promises } from "fs";
 import path from "path";
 import process from "process";
 import Influx from "influx";
+import { default_config } from "../config/config.ts";
 import type { Config } from "../config/config.types.ts";
 import { fetchPrices } from "./priceService.ts";
 import { fetchSolarForecast } from "./solarForecast.ts";
@@ -71,6 +72,8 @@ const input: PlannerInput = {
   sellVetoWindows: [],
   buyVetoWindows: [],
   knobs: {
+    // Backfill knobs the config file predates, same as the live config merge does
+    ...default_config.automatic_trading,
     ...at,
     runtime_soc_floor_percent: Number(config.scheduled_power_selling.only_sell_above_soc),
     baseline_feed_watts: config.feed_from_battery_when_no_solar.feed_amount_watts,

--- a/backend/src/autoTrading/planner.selftest.ts
+++ b/backend/src/autoTrading/planner.selftest.ts
@@ -26,9 +26,12 @@ const baseKnobs = {
   sell_bonus_sek_per_kwh: 0.092,
   min_buy_saving_sek_per_kwh: 0.3,
   baseline_feed_watts: 350,
-  // Existing scenarios predate ramp modeling and arbitrage — keep them isolated
+  // Existing scenarios predate ramp modeling, arbitrage, the restart penalty and the sunny
+  // floor — keep them isolated (sunny floor == planner floor disables the relaxation)
   sell_ramp_minutes: 0,
   allow_arbitrage_buying: false,
+  sell_restart_penalty_sek: 0,
+  planner_soc_floor_sunny_percent: 20,
 };
 
 // t0 = a midnight-aligned "now"
@@ -415,6 +418,146 @@ function check(name: string, cond: boolean, detail = "") {
     "settle: import cost = kWh × (spot + surcharge) × VAT, negative revenue",
     Math.abs(bought.revenue_sek - -(4 * (0.5 + 1.186) * 1.25)) < 0.05,
     `(${bought.revenue_sek})`
+  );
+}
+
+// ---------- Scenario 10: tight budget + zigzagging 15-min prices → contiguous windows, not a comb ----------
+// Reproduces the 2026-07-07/08 shape: the greedy takes the top-priced quarters, which zigzag
+// scatters, and near budget exhaustion only ramp-crippled isolated slots still "fit" — 15-min
+// holes everywhere. The restart penalty + consolidation pass must merge them.
+{
+  const sunnyDay = (h: number) => {
+    const hh = h % 24;
+    return hh >= 6 && hh <= 20 ? Math.max(0, Math.sin(((hh - 6) / 14) * Math.PI)) * 12000 : 0;
+  };
+  // Evening peak with per-quarter zigzag (öre-level, like real 15-min day-ahead prices)
+  const priceCurve = (h: number) => {
+    const hh = h % 24;
+    if (hh >= 19 && hh < 22.01) {
+      const quarter = Math.round((hh % 1) * 4) % 4;
+      return 1.0 + [0.03, 0, 0.02, -0.01][quarter] - 0.005 * (hh - 19);
+    }
+    return 0.35;
+  };
+  const mk = (penalty: number): PlannerInput => ({
+    nowMs: t0 + 17 * H,
+    prices: mkPrices(36, priceCurve),
+    solarWattsAt: ms => sunnyDay((ms - t0) / H),
+    houseLoadWattsAt: () => 600,
+    parasiticWatts: 230,
+    socPercent: 52,
+    capacityWh: 65000,
+    constraintTailHours: 12,
+    fixedSells: [],
+    fixedBuys: [],
+    sellVetoWindows: [],
+    buyVetoWindows: [],
+    knobs: { ...baseKnobs, sell_ramp_minutes: 10, min_window_minutes: 15, sell_restart_penalty_sek: penalty },
+  });
+  const plan = generatePlan(mk(1));
+  const sells = [...plan.sells].sort((a, b) => a.startMs - b.startMs);
+  const chains = sells.filter((w, i) => i === 0 || sells[i - 1].endMs !== w.startMs).length;
+  check("consolidate: sells exist under tight budget", sells.length > 0, `(${sells.length} windows)`);
+  check("consolidate: one contiguous chain, no holes", chains <= 1, `(${chains} chains)`);
+  check(
+    "consolidate: floor respected",
+    plan.projection.minSocPercent >= 19.9,
+    `(min SOC ${plan.projection.minSocPercent}%)`
+  );
+  check(
+    "consolidate: budget actually used",
+    plan.projection.plannedSellKwh > 8,
+    `(${plan.projection.plannedSellKwh} kWh)`
+  );
+  console.log("  sells:", sells.map(w => `h${(w.startMs - t0) / H}-h${(w.endMs - t0) / H}@${w.watts}W`).join(", "));
+}
+
+// ---------- Scenario 11: sunny floor — morning selling may dip below the night floor ----------
+{
+  const sunnyDay = (h: number) => {
+    const hh = h % 24;
+    return hh >= 6 && hh <= 20 ? Math.max(0, Math.sin(((hh - 6) / 14) * Math.PI)) * 12000 : 0;
+  };
+  // Morning price peak while solar already covers the house
+  const priceCurve = (h: number) => {
+    const hh = h % 24;
+    if (hh >= 8 && hh <= 10) return 1.5;
+    return 0.3;
+  };
+  const mk = (sunnyFloor: number): PlannerInput => ({
+    nowMs: t0 + 6 * H,
+    prices: mkPrices(30, priceCurve),
+    solarWattsAt: ms => sunnyDay((ms - t0) / H),
+    houseLoadWattsAt: () => 600,
+    parasiticWatts: 230,
+    socPercent: 35,
+    capacityWh: 65000,
+    constraintTailHours: 12,
+    fixedSells: [],
+    fixedBuys: [],
+    sellVetoWindows: [],
+    buyVetoWindows: [],
+    knobs: {
+      ...baseKnobs,
+      planner_soc_floor_sunny_percent: sunnyFloor,
+      runtime_soc_floor_percent: 5,
+    },
+  });
+  const strict = generatePlan(mk(20)); // sunny floor == planner floor → old behavior
+  const relaxed = generatePlan(mk(5));
+  check(
+    "sunnyfloor: relaxed floor sells more at the morning peak",
+    relaxed.projection.plannedSellKwh > strict.projection.plannedSellKwh + 5,
+    `(${relaxed.projection.plannedSellKwh} vs ${strict.projection.plannedSellKwh} kWh)`
+  );
+  check(
+    "sunnyfloor: dips below the night floor but not below the sunny floor",
+    relaxed.projection.minSocPercent < 19 && relaxed.projection.minSocPercent >= 4.9,
+    `(min SOC ${relaxed.projection.minSocPercent}%)`
+  );
+  const minAtHour = (new Date(relaxed.projection.minSocAt).getTime() - t0) / H;
+  check("sunnyfloor: the dip happens while the sun is up", minAtHour >= 6 && minAtHour <= 20, `(h${minAtHour})`);
+}
+
+// ---------- Scenario 12: reconcile shape (2026-07-06 incident) — after the evening window falls, ----------
+// the planner re-fills what is feasible instead of leaving the schedule stranded
+{
+  const priceCurve = (h: number) => {
+    if (h >= 19 && h <= 21) return 1.1; // tonight's peak
+    if (h >= 29 && h <= 31) return 1.05; // tomorrow 05:00-07:00
+    return 0.4;
+  };
+  const sunnyDay = (h: number) => {
+    const hh = h % 24;
+    return hh >= 6 && hh <= 20 ? Math.max(0, Math.sin(((hh - 6) / 14) * Math.PI)) * 12000 : 0;
+  };
+  // 20:00, evening window just got dropped by the guard (SOC too low to run it): can morning
+  // windows come back? The guard now answers by re-planning — this is that re-plan.
+  const input: PlannerInput = {
+    nowMs: t0 + 20 * H,
+    prices: mkPrices(48, priceCurve),
+    solarWattsAt: ms => sunnyDay((ms - t0) / H),
+    houseLoadWattsAt: () => 800,
+    parasiticWatts: 230,
+    socPercent: 50,
+    capacityWh: 65000,
+    constraintTailHours: 12,
+    fixedSells: [],
+    fixedBuys: [],
+    sellVetoWindows: [],
+    buyVetoWindows: [],
+    knobs: { ...baseKnobs, min_window_minutes: 15 },
+  };
+  const plan = generatePlan(input);
+  check("reconcile: re-plan finds feasible sell windows", plan.sells.length > 0, `(${plan.sells.length} windows)`);
+  check(
+    "reconcile: floor still respected",
+    plan.projection.minSocPercent >= 19.9,
+    `(min SOC ${plan.projection.minSocPercent}%)`
+  );
+  console.log(
+    "  sells:",
+    plan.sells.map(w => `h${(w.startMs - t0) / H}-h${(w.endMs - t0) / H}@${w.avgSpot.toFixed(2)}`).join(", ")
   );
 }
 

--- a/backend/src/autoTrading/planner.selftest.ts
+++ b/backend/src/autoTrading/planner.selftest.ts
@@ -26,11 +26,10 @@ const baseKnobs = {
   sell_bonus_sek_per_kwh: 0.092,
   min_buy_saving_sek_per_kwh: 0.3,
   baseline_feed_watts: 350,
-  // Existing scenarios predate ramp modeling, arbitrage, the restart penalty and the sunny
-  // floor — keep them isolated (sunny floor == planner floor disables the relaxation)
+  // Existing scenarios predate ramp modeling, arbitrage and the sunny floor — keep them
+  // isolated (sunny floor == planner floor disables the relaxation)
   sell_ramp_minutes: 0,
   allow_arbitrage_buying: false,
-  sell_restart_penalty_sek: 0,
   planner_soc_floor_sunny_percent: 20,
 };
 
@@ -421,10 +420,12 @@ function check(name: string, cond: boolean, detail = "") {
   );
 }
 
-// ---------- Scenario 10: tight budget + zigzagging 15-min prices → contiguous windows, not a comb ----------
-// Reproduces the 2026-07-07/08 shape: the greedy takes the top-priced quarters, which zigzag
-// scatters, and near budget exhaustion only ramp-crippled isolated slots still "fit" — 15-min
-// holes everywhere. The restart penalty + consolidation pass must merge them.
+// ---------- Scenario 10: tight budget + zigzagging 15-min prices → consolidation cleans up ----------
+// The 2026-07-07/08 shape: the greedy takes the top-priced quarters, which zigzag scatters, and
+// near budget exhaustion only ramp-crippled isolated slots still "fit". Combs that genuinely
+// price better are kept (a stop/start costs nothing but the ramp), but consolidation must
+// harvest what the greedy strands: ramp-recovering merges and — key — fractional leftover
+// budget as reduced-power window extensions instead of nothing.
 {
   const sunnyDay = (h: number) => {
     const hh = h % 24;
@@ -439,7 +440,7 @@ function check(name: string, cond: boolean, detail = "") {
     }
     return 0.35;
   };
-  const mk = (penalty: number): PlannerInput => ({
+  const input: PlannerInput = {
     nowMs: t0 + 17 * H,
     prices: mkPrices(36, priceCurve),
     solarWattsAt: ms => sunnyDay((ms - t0) / H),
@@ -452,13 +453,16 @@ function check(name: string, cond: boolean, detail = "") {
     fixedBuys: [],
     sellVetoWindows: [],
     buyVetoWindows: [],
-    knobs: { ...baseKnobs, sell_ramp_minutes: 10, min_window_minutes: 15, sell_restart_penalty_sek: penalty },
-  });
-  const plan = generatePlan(mk(1));
+    knobs: { ...baseKnobs, sell_ramp_minutes: 10, min_window_minutes: 15 },
+  };
+  const plan = generatePlan(input);
   const sells = [...plan.sells].sort((a, b) => a.startMs - b.startMs);
-  const chains = sells.filter((w, i) => i === 0 || sells[i - 1].endMs !== w.startMs).length;
   check("consolidate: sells exist under tight budget", sells.length > 0, `(${sells.length} windows)`);
-  check("consolidate: one contiguous chain, no holes", chains <= 1, `(${chains} chains)`);
+  check(
+    "consolidate: fractional budget captured at reduced power",
+    sells.some(w => w.watts < baseKnobs.max_sell_power_watts),
+    `(watts: ${sells.map(w => w.watts).join(", ")})`
+  );
   check(
     "consolidate: floor respected",
     plan.projection.minSocPercent >= 19.9,

--- a/backend/src/autoTrading/planner.ts
+++ b/backend/src/autoTrading/planner.ts
@@ -8,16 +8,19 @@
  * arbitrage when a later sell clears the full fee + round-trip-loss + margin stack.
  *
  * Strategy: simulate battery SOC over the price horizon (+ a constraint tail covering the following night)
- * using solar + consumption forecasts, then greedily allocate 15-min sell slots from the highest spot price
- * down, keeping every accepted plan feasible (SOC never below the planner floor + user reserve). Selling
- * energy the battery couldn't have absorbed anyway (would have auto-exported when full) is naturally handled
- * by the simulation's revenue accounting.
+ * using solar + consumption forecasts (simulate.ts), then greedily allocate 15-min sell slots from the
+ * highest spot price down, keeping every accepted plan feasible (SOC never below the planner floor + user
+ * reserve). Selling energy the battery couldn't have absorbed anyway (would have auto-exported when full)
+ * is naturally handled by the simulation's revenue accounting.
  *
  * Two forces keep the schedule contiguous: every sell-run start is charged sell_restart_penalty_sek in the
- * simulation, and a consolidation pass (see consolidateSellSlots) defragments what the greedy scattered.
- * The reserve floor relaxes to planner_soc_floor_sunny_percent in slots where forecast PV covers the house.
+ * optimizer objective (objectiveSek — reported cash revenue stays clean of it), and a consolidation pass
+ * (sellConsolidation.ts) defragments what the greedy scattered. The reserve floor relaxes to
+ * planner_soc_floor_sunny_percent in slots where forecast PV covers the house.
  */
 
+import { objectiveSek, overlapsVeto, simulate, slotTradableForSell } from "./simulate.ts";
+import { consolidateSellSlots } from "./sellConsolidation.ts";
 import type {
   FixedWindow,
   PlannedWindow,
@@ -29,396 +32,6 @@ import type {
 } from "./planner.types.ts";
 
 export const SLOT_MS = 15 * 60 * 1000;
-
-function windowPowerAt(windows: FixedWindow[], startMs: number, endMs: number): number {
-  let max = 0;
-  for (const w of windows) {
-    if (w.startMs < endMs && w.endMs > startMs) max = Math.max(max, w.watts);
-  }
-  return max;
-}
-
-function buildSlots(input: PlannerInput): Slot[] {
-  const { prices, nowMs, constraintTailHours, solarWattsAt, houseLoadWattsAt, fixedSells, fixedBuys } = input;
-  const slots: Slot[] = [];
-  const relevantPrices = prices.filter(p => p.startMs + SLOT_MS > nowMs).sort((a, b) => a.startMs - b.startMs);
-  const pricedEndMs = relevantPrices.length ? relevantPrices[relevantPrices.length - 1].startMs + SLOT_MS : nowMs;
-  const tailEndMs = pricedEndMs + constraintTailHours * 3600 * 1000;
-
-  const pushSlot = (startMs: number, spot: number | undefined) => {
-    const endMs = startMs + SLOT_MS;
-    const effectiveStart = Math.max(startMs, nowMs);
-    const durationH = (endMs - effectiveStart) / 3600_000;
-    if (durationH <= 0) return;
-    const midMs = (effectiveStart + endMs) / 2;
-    slots.push({
-      startMs,
-      endMs,
-      durationH,
-      spot,
-      pvW: Math.max(0, input.solarWattsAt(midMs)),
-      houseW: Math.max(0, houseLoadWattsAt(midMs)),
-      fixedSellW: windowPowerAt(fixedSells, startMs, endMs),
-      fixedBuyW: windowPowerAt(fixedBuys, startMs, endMs),
-    });
-  };
-
-  for (const p of relevantPrices) pushSlot(p.startMs, p.spot);
-  for (let t = pricedEndMs; t < tailEndMs; t += SLOT_MS) pushSlot(t, undefined);
-  return slots;
-}
-
-function simulate(input: PlannerInput, slots: Slot[], sellW: number[], buyW: number[], tailSpot: number): SimResult {
-  const k = input.knobs;
-  const cap = input.capacityWh;
-  const floorPlannerWh = (k.planner_soc_floor_percent / 100) * cap + k.extra_reserve_kwh * 1000;
-  // While forecast PV covers the house, a forecast miss costs minutes of import instead of a
-  // stranded night — the reserve requirement drops accordingly (never above the normal floor).
-  const floorSunnyWh = Math.min(
-    (k.planner_soc_floor_sunny_percent / 100) * cap + k.extra_reserve_kwh * 1000,
-    floorPlannerWh
-  );
-  const floorRuntimeWh = (k.runtime_soc_floor_percent / 100) * cap;
-  const floorEmergencyWh = (k.emergency_soc_floor_percent / 100) * cap;
-
-  let socWh = (input.socPercent / 100) * cap;
-  let revenueSek = 0;
-  let violationWh = 0;
-  let minSocWh = socWh;
-  let minSocMs = input.nowMs;
-  let sellExportWh = 0;
-  let autoExportWh = 0;
-  let importWh = 0;
-  let boughtWh = 0;
-  const socAfterSlot: number[] = new Array(slots.length);
-  // Minutes of continuous selling so far — the inverter ramps grid feed-in slowly (grid safety),
-  // so the first sell_ramp_minutes of every (re)start deliver reduced power.
-  let sellRunMinutes = 0;
-
-  for (let i = 0; i < slots.length; i++) {
-    const s = slots[i];
-    const spot = s.spot ?? tailSpot;
-    const parasiticW = input.parasiticWatts;
-    const sellSetW = Math.max(sellW[i], s.fixedSellW);
-    const requestedBuyW = Math.max(buyW[i], s.fixedBuyW);
-    // Runtime never does both at once (feedWhenNoSolar errors out) — selling wins in our model
-    const buySetW = sellSetW > 0 ? 0 : requestedBuyW;
-
-    let exportW = 0;
-    let gridChargeW = 0;
-    let slotImportWh = 0;
-
-    if (buySetW > 0 && socWh < cap * 0.98) {
-      // AC charging: battery charges from grid, house is fed from grid too
-      gridChargeW = buySetW;
-      slotImportWh +=
-        (buySetW + s.houseW + parasiticW - Math.min(s.pvW, buySetW + s.houseW + parasiticW)) * s.durationH;
-      boughtWh += buySetW * s.durationH;
-    }
-
-    const sellingThisSlot = sellSetW > 0 && socWh > floorRuntimeWh;
-    if (sellingThisSlot) {
-      // Starting a feed-in run costs more than the modeled ramp: inverter mode/relay churn,
-      // and schedules full of holes that nobody asked for. Charge each run start for it.
-      if (sellRunMinutes === 0) revenueSek -= k.sell_restart_penalty_sek;
-      // Export is limited by what battery + PV can physically supply beyond the house
-      // House has first dibs on the inverter's AC output; export gets the rest of the 15 kW rating
-      exportW = Math.min(sellSetW, k.inverter_max_ac_output_watts - s.houseW);
-      exportW = Math.max(exportW, 0);
-      // Average ramp factor over this slot: linear 0→100% across the first sell_ramp_minutes of the run
-      const rampMin = k.sell_ramp_minutes;
-      if (rampMin > 0 && sellRunMinutes < rampMin) {
-        const slotMin = s.durationH * 60;
-        const e0 = sellRunMinutes;
-        const e1 = e0 + slotMin;
-        const rampedUntil = Math.min(e1, rampMin);
-        const avgFactor =
-          ((rampedUntil * rampedUntil - e0 * e0) / (2 * rampMin) + Math.max(0, e1 - rampedUntil)) / slotMin;
-        exportW *= avgFactor;
-      }
-      sellRunMinutes += s.durationH * 60;
-    } else {
-      sellRunMinutes = 0;
-      if (buySetW === 0 && s.pvW < s.houseW + parasiticW + 380) {
-        // Baseline "feed when no solar" that nets out the inverter's constant grid draw
-        exportW = k.baseline_feed_watts;
-      }
-    }
-
-    let netBattW: number;
-    if (gridChargeW > 0) {
-      netBattW = s.pvW + gridChargeW;
-    } else {
-      netBattW = s.pvW - s.houseW - parasiticW - exportW;
-    }
-    const deltaWh =
-      netBattW >= 0 ? netBattW * k.charge_efficiency * s.durationH : (netBattW / k.discharge_efficiency) * s.durationH;
-    socWh += deltaWh;
-
-    if (socWh > cap) {
-      // Battery full: surplus PV flows to the grid by itself (solar-mode feeding)
-      const overflowInBatteryWh = socWh - cap;
-      autoExportWh += overflowInBatteryWh / k.charge_efficiency;
-      revenueSek += (overflowInBatteryWh / k.charge_efficiency / 1000) * (spot + k.sell_bonus_sek_per_kwh);
-      socWh = cap;
-    }
-    if (socWh < floorEmergencyWh) {
-      // Battery can't go lower — the house pulls the deficit from the grid (unavoidable import)
-      const deficitWh = floorEmergencyWh - socWh;
-      const importedForHouseWh = deficitWh * k.discharge_efficiency;
-      slotImportWh += importedForHouseWh;
-      socWh = floorEmergencyWh;
-    }
-
-    const exportedWh = exportW * s.durationH;
-    sellExportWh += sellSetW > 0 ? exportedWh : 0;
-    revenueSek += (exportedWh / 1000) * (spot + k.sell_bonus_sek_per_kwh);
-    importWh += slotImportWh;
-    revenueSek -= (slotImportWh / 1000) * (spot + k.buy_surcharges_sek_per_kwh) * k.vat_multiplier;
-
-    const floorWh = s.pvW > s.houseW + parasiticW ? floorSunnyWh : floorPlannerWh;
-    if (socWh < floorWh) violationWh += floorWh - socWh;
-    if (socWh < minSocWh) {
-      minSocWh = socWh;
-      minSocMs = s.endMs;
-    }
-    socAfterSlot[i] = socWh;
-  }
-
-  return {
-    revenueSek,
-    violationWh,
-    minSocWh,
-    minSocMs,
-    endSocWh: socWh,
-    sellExportWh,
-    autoExportWh,
-    importWh,
-    boughtWh,
-    socAfterSlot,
-  };
-}
-
-type MergedWindow = { startMs: number; endMs: number; watts: number; kind: "sell" | "buy"; slotIndexes: number[] };
-
-function mergeAcceptedSlots(
-  slots: Slot[],
-  accepted: number[],
-  wattsBySlot: number[],
-  kind: "sell" | "buy",
-  min_window_minutes: number
-): {
-  windows: MergedWindow[];
-  droppedShort: number;
-} {
-  const sorted = [...accepted].sort((a, b) => a - b);
-  const windows: MergedWindow[] = [];
-  for (const i of sorted) {
-    const last = windows[windows.length - 1];
-    if (last && slots[i].startMs === last.endMs && wattsBySlot[i] === last.watts) {
-      last.endMs = slots[i].endMs;
-      last.slotIndexes.push(i);
-    } else {
-      windows.push({ startMs: slots[i].startMs, endMs: slots[i].endMs, watts: wattsBySlot[i], kind, slotIndexes: [i] });
-    }
-  }
-  // A power step mid-run splits into adjacent windows that are still one continuous feed —
-  // the minimum-length rule judges the whole contiguous chain, not each window.
-  const chains: MergedWindow[][] = [];
-  for (const w of windows) {
-    const lastChain = chains[chains.length - 1];
-    if (lastChain && lastChain[lastChain.length - 1].endMs === w.startMs) lastChain.push(w);
-    else chains.push([w]);
-  }
-  const kept: MergedWindow[] = [];
-  let droppedShort = 0;
-  for (const chain of chains) {
-    const chainMinutes = (chain[chain.length - 1].endMs - chain[0].startMs) / 60000;
-    if (chainMinutes >= min_window_minutes) kept.push(...chain);
-    else droppedShort += chain.length;
-  }
-  return { windows: kept, droppedShort };
-}
-
-/**
- * Defragment the greedy's sell allocation. Under a binding reserve budget the greedy takes the
- * top-priced 15-min slots, which zigzagging 15-min prices scatter into combs — and the ramp model
- * amplifies that: near budget exhaustion a full-power contiguous slot no longer fits while an
- * isolated (ramp-crippled, ~2/3 energy) slot still does, so holes win systematically. Local-search
- * moves repair this, each re-simulated and only applied when feasible and simulated revenue
- * improves (the restart penalty is what tips consolidation into "improves"):
- *   - fill a one-slot hole between runs, alone (full or reduced power) or funded by dropping the
- *     cheapest edge slot of another run
- *   - merge two neighbouring runs by relocating the smaller flush against the larger (covers
- *     single-slot teeth as the degenerate case) — öre of price cost against whole SEK of penalty
- *   - extend a run edge at reduced power, so a fractional leftover budget still gets sold instead
- *     of spawning a remote ramp-crippled tooth (pure adds must clear min_gain_sek_per_slot and the
- *     min sell spot, like the greedy's adds)
- * Mutates sellW in place; returns the simulation state it converged on.
- */
-function consolidateSellSlots(
-  input: PlannerInput,
-  slots: Slot[],
-  sellW: number[],
-  buyW: number[],
-  tailSpot: number,
-  feasible: (r: SimResult) => boolean,
-  current: SimResult
-): SimResult {
-  const k = input.knobs;
-  const fillable = (j: number) =>
-    j >= 0 &&
-    j < slots.length &&
-    sellW[j] === 0 &&
-    buyW[j] === 0 &&
-    slots[j].spot !== undefined &&
-    slots[j].fixedSellW === 0 &&
-    slots[j].fixedBuyW === 0 &&
-    !input.sellVetoWindows.some(v => v.startMs < slots[j].endMs && v.endMs > slots[j].startMs);
-  const timeAdjacent = (i: number, j: number) =>
-    slots[i] !== undefined && slots[j] !== undefined && slots[j].startMs === slots[i].endMs;
-
-  const computeRuns = () => {
-    const runs: number[][] = [];
-    for (let i = 0; i < slots.length; i++) {
-      if (sellW[i] <= 0) continue;
-      const lastRun = runs[runs.length - 1];
-      const prev = lastRun?.[lastRun.length - 1];
-      if (prev !== undefined && timeAdjacent(prev, i)) lastRun.push(i);
-      else runs.push([i]);
-    }
-    return runs;
-  };
-
-  let trialsLeft = 400;
-  const accept = (minGainSek: number): boolean => {
-    if (trialsLeft-- <= 0) return false;
-    const trial = simulate(input, slots, sellW, buyW, tailSpot);
-    if (feasible(trial) && trial.revenueSek > current.revenueSek + Math.max(minGainSek, 1e-6)) {
-      current = trial;
-      return true;
-    }
-    return false;
-  };
-
-  // Add one slot (full power first, reduced captures fractional budgets), optionally funded by
-  // dropping another. Funded moves are ~energy-neutral and need no extra gain; pure adds clear
-  // the same min-gain bar as the greedy's.
-  const tryFill = (dropIdx: number | undefined, addIdx: number): boolean => {
-    const savedDrop = dropIdx !== undefined ? sellW[dropIdx] : 0;
-    if (dropIdx !== undefined) sellW[dropIdx] = 0;
-    for (const factor of [1, 2 / 3, 1 / 2, 1 / 3]) {
-      sellW[addIdx] = Math.round(k.max_sell_power_watts * factor);
-      if (accept(dropIdx === undefined ? k.min_gain_sek_per_slot : 0)) return true;
-    }
-    sellW[addIdx] = 0;
-    if (dropIdx !== undefined) sellW[dropIdx] = savedDrop;
-    return false;
-  };
-
-  // Relocate a whole run onto a target position. The move changes ramp state (e.g. a crippled
-  // isolated slot becomes a full-power run member), so scaled-down watts are also tried — that
-  // lets an energy-equivalent relocation through a binding budget.
-  const tryRelocateRun = (run: number[], targets: number[]): boolean => {
-    const savedWatts = run.map(i => sellW[i]);
-    for (const i of run) sellW[i] = 0;
-    if (targets.every(fillable)) {
-      for (const factor of [1, 2 / 3, 1 / 2, 1 / 3]) {
-        targets.forEach((j, idx) => (sellW[j] = Math.round(savedWatts[idx] * factor)));
-        if (accept(0)) return true;
-      }
-      for (const j of targets) sellW[j] = 0;
-    }
-    run.forEach((i, idx) => (sellW[i] = savedWatts[idx]));
-    return false;
-  };
-
-  let movesLeft = 24;
-  outer: while (movesLeft-- > 0 && trialsLeft > 0) {
-    const runs = computeRuns();
-    if (!runs.length) break;
-
-    // 1. One-slot holes between consecutive runs: fill, else fund by dropping the cheapest edge
-    //    slot of some run (never a slot adjacent to the hole — that just moves it)
-    const edges = runs
-      .flatMap(run => (run.length === 1 ? [run[0]] : [run[0], run[run.length - 1]]))
-      .sort((a, b) => (slots[a].spot ?? 0) - (slots[b].spot ?? 0));
-    for (let runIdx = 0; runIdx + 1 < runs.length; runIdx++) {
-      const hole = runs[runIdx][runs[runIdx].length - 1] + 1;
-      if (runs[runIdx + 1][0] !== hole + 1 || !fillable(hole)) continue;
-      if (!timeAdjacent(hole - 1, hole) || !timeAdjacent(hole, hole + 1)) continue;
-      if (tryFill(undefined, hole)) continue outer;
-      for (const edge of edges) {
-        if (Math.abs(edge - hole) <= 1) continue;
-        if (tryFill(edge, hole)) continue outer;
-      }
-    }
-
-    // 2. Merge neighbouring runs by relocating one flush against the other. Try the cheaper
-    //    relocation (fewer slots moved) first, then the reverse.
-    for (let runIdx = 0; runIdx + 1 < runs.length; runIdx++) {
-      const before = runs[runIdx];
-      const after = runs[runIdx + 1];
-      if (after[0] - before[before.length - 1] < 2) continue;
-      // A run relocated flush against the other: target indexes + the anchor slot they must touch
-      const flushRight = (moved: number[]) => ({
-        moved,
-        targets: moved.map((_, idx) => after[0] - moved.length + idx),
-        anchor: after[0],
-      });
-      const flushLeft = (moved: number[]) => ({
-        moved,
-        targets: moved.map((_, idx) => before[before.length - 1] + 1 + idx),
-        anchor: before[before.length - 1],
-      });
-      const attempts =
-        before.length <= after.length ? [flushRight(before), flushLeft(after)] : [flushLeft(after), flushRight(before)];
-      for (const { moved, targets, anchor } of attempts) {
-        const chain = [...targets, anchor].sort((a, b) => a - b);
-        if (!chain.every((idx, pos) => pos === 0 || timeAdjacent(chain[pos - 1], idx))) continue;
-        if (tryRelocateRun(moved, targets)) continue outer;
-      }
-    }
-
-    // 3. Extend run edges at reduced power — mops up a leftover budget fraction
-    for (const run of runs) {
-      const first = run[0];
-      const last = run[run.length - 1];
-      for (const target of [first - 1, last + 1]) {
-        if (!fillable(target)) continue;
-        if (!(target < first ? timeAdjacent(target, first) : timeAdjacent(last, target))) continue;
-        if ((slots[target].spot ?? 0) < k.min_sell_spot_sek_per_kwh) continue;
-        if (tryFill(undefined, target)) continue outer;
-      }
-    }
-    break;
-  }
-
-  // Finally, equalize power across each chain's post-ramp body: same energy (mean rounded down),
-  // ± öre of revenue, and the schedule collapses to a couple of entries instead of the power
-  // staircase reduced-power fills leave behind. Slots still inside the ramp window keep their
-  // power — the ramp caps their export, so averaging power away from them loses real energy.
-  for (const run of computeRuns()) {
-    let offsetMinutes = 0;
-    const body: number[] = [];
-    for (const i of run) {
-      if (offsetMinutes >= k.sell_ramp_minutes) body.push(i);
-      offsetMinutes += slots[i].durationH * 60;
-    }
-    if (body.length < 2 || new Set(body.map(i => sellW[i])).size <= 1) continue;
-    if (trialsLeft-- <= 0) break;
-    const savedWatts = body.map(i => sellW[i]);
-    const meanWatts = Math.floor(savedWatts.reduce((a, b) => a + b, 0) / body.length / 100) * 100;
-    for (const i of body) sellW[i] = meanWatts;
-    const trial = simulate(input, slots, sellW, buyW, tailSpot);
-    if (feasible(trial) && trial.revenueSek >= current.revenueSek - 0.1 * body.length) {
-      current = trial;
-    } else {
-      body.forEach((i, idx) => (sellW[i] = savedWatts[idx]));
-    }
-  }
-  return current;
-}
 
 export function generatePlan(input: PlannerInput): PlanResult {
   const k = input.knobs;
@@ -449,18 +62,9 @@ export function generatePlan(input: PlannerInput): PlanResult {
   const feasibleVsBase = (r: SimResult) => r.violationWh <= base.violationWh + 1;
 
   // ---- Greedy sell allocation, highest spot first ----
-  const overlapsVeto = (s: Slot, vetoes: { startMs: number; endMs: number }[]) =>
-    vetoes.some(v => v.startMs < s.endMs && v.endMs > s.startMs);
   const sellCandidates = slots
     .map((s, i) => ({ s, i }))
-    .filter(
-      ({ s }) =>
-        s.spot !== undefined &&
-        s.spot >= k.min_sell_spot_sek_per_kwh &&
-        s.fixedSellW === 0 &&
-        s.fixedBuyW === 0 &&
-        !overlapsVeto(s, input.sellVetoWindows)
-    )
+    .filter(({ s }) => slotTradableForSell(s, input.sellVetoWindows) && s.spot! >= k.min_sell_spot_sek_per_kwh)
     .sort((a, b) => b.s.spot! - a.s.spot!);
 
   let current = base;
@@ -468,7 +72,7 @@ export function generatePlan(input: PlannerInput): PlanResult {
   for (const { i } of sellCandidates) {
     sellW[i] = k.max_sell_power_watts;
     const trial = simulate(input, slots, sellW, buyW, tailSpot);
-    const gain = trial.revenueSek - current.revenueSek;
+    const gain = objectiveSek(trial) - objectiveSek(current);
     if (feasibleVsBase(trial) && gain >= k.min_gain_sek_per_slot) {
       current = trial;
       acceptedSell.push(i);
@@ -478,9 +82,9 @@ export function generatePlan(input: PlannerInput): PlanResult {
   }
 
   // Bridge short price valleys between accepted windows: every feed stop/start restarts the
-  // slow feed-in ramp (which the simulation prices in), so selling through a shallow dip is
-  // usually better than pausing — and nobody wants a schedule with a 30-min hole in it.
-  // Accept a bounded revenue loss per bridged slot; the sim decides using ramp + prices.
+  // slow feed-in ramp and pays the restart penalty (both priced into the objective), so selling
+  // through a shallow dip is usually better than pausing — and nobody wants a schedule with a
+  // 30-min hole in it. Accept a bounded objective loss per bridged slot; the sim decides.
   const maxGapSlots = 3;
   const maxSmoothingLossSekPerSlot = 1;
   for (let pass = 0, changed = true; pass < 4 && changed; pass++) {
@@ -494,14 +98,7 @@ export function generatePlan(input: PlannerInput): PlanResult {
       if (slots[after].startMs - slots[before].endMs !== gapSlots * SLOT_MS) continue;
       const fillable: number[] = [];
       for (let j = before + 1; j < after; j++) {
-        const s = slots[j];
-        if (
-          sellW[j] > 0 ||
-          s.spot === undefined ||
-          s.fixedSellW > 0 ||
-          s.fixedBuyW > 0 ||
-          overlapsVeto(s, input.sellVetoWindows)
-        ) {
+        if (sellW[j] > 0 || !slotTradableForSell(slots[j], input.sellVetoWindows)) {
           fillable.length = 0;
           break;
         }
@@ -510,7 +107,10 @@ export function generatePlan(input: PlannerInput): PlanResult {
       if (fillable.length !== gapSlots) continue;
       for (const j of fillable) sellW[j] = k.max_sell_power_watts;
       const trial = simulate(input, slots, sellW, buyW, tailSpot);
-      if (feasibleVsBase(trial) && trial.revenueSek - current.revenueSek >= -maxSmoothingLossSekPerSlot * gapSlots) {
+      if (
+        feasibleVsBase(trial) &&
+        objectiveSek(trial) - objectiveSek(current) >= -maxSmoothingLossSekPerSlot * gapSlots
+      ) {
         current = trial;
         acceptedSell.push(...fillable);
         changed = true;
@@ -520,7 +120,7 @@ export function generatePlan(input: PlannerInput): PlanResult {
     }
   }
 
-  // Defragment what the greedy scattered (see consolidateSellSlots) — sellW is the source of
+  // Defragment what the greedy scattered (see sellConsolidation.ts) — sellW is the source of
   // truth afterwards, so rebuild the accepted list from it
   current = consolidateSellSlots(input, slots, sellW, buyW, tailSpot, feasibleVsBase, current);
   acceptedSell.length = 0;
@@ -543,7 +143,7 @@ export function generatePlan(input: PlannerInput): PlanResult {
       if (sellW[i] > 0) continue;
       buyW[i] = k.max_buy_power_watts;
       const trial = simulate(input, slots, sellW, buyW, tailSpot);
-      const gain = trial.revenueSek - current.revenueSek;
+      const gain = objectiveSek(trial) - objectiveSek(current);
       const extraBoughtKwh = (trial.boughtWh - current.boughtWh) / 1000;
       if (feasibleVsBase(trial) && extraBoughtKwh > 0 && gain / extraBoughtKwh >= k.min_buy_saving_sek_per_kwh) {
         current = trial;
@@ -609,7 +209,7 @@ export function generatePlan(input: PlannerInput): PlanResult {
         for (const b of buyGroup) buyW[b] = k.max_buy_power_watts;
         sellW[sellIdx] = k.max_sell_power_watts;
         const trial = simulate(input, slots, sellW, buyW, tailSpot);
-        const gain = trial.revenueSek - current.revenueSek;
+        const gain = objectiveSek(trial) - objectiveSek(current);
         const extraBoughtKwh = (trial.boughtWh - current.boughtWh) / 1000;
         if (feasibleVsBase(trial) && extraBoughtKwh > 0.1 && gain / extraBoughtKwh >= k.min_buy_saving_sek_per_kwh) {
           current = trial;
@@ -664,13 +264,7 @@ export function generatePlan(input: PlannerInput): PlanResult {
   const spotsAll = pricedSlots.map(s => s.spot!).sort((a, b) => a - b);
   const percentileOf = (v: number) => Math.round((spotsAll.filter(x => x <= v).length / spotsAll.length) * 100);
 
-  const toPlanned = (w: {
-    startMs: number;
-    endMs: number;
-    watts: number;
-    kind: "sell" | "buy";
-    slotIndexes: number[];
-  }): PlannedWindow => {
+  const toPlanned = (w: MergedWindow): PlannedWindow => {
     const spots = w.slotIndexes.map(i => slots[i].spot!).filter(v => v !== undefined);
     const avgSpot = spots.reduce((a, b) => a + b, 0) / Math.max(spots.length, 1);
     const socBefore = current.socAfterSlot[Math.max(0, w.slotIndexes[0] - 1)] ?? (input.socPercent / 100) * cap;
@@ -753,6 +347,93 @@ export function projectWithFixedWindows(input: PlannerInput): {
     endSocPercent: Math.round((r.endSocWh / input.capacityWh) * 1000) / 10,
     revenueSek: Math.round(r.revenueSek * 10) / 10,
   };
+}
+
+function windowPowerAt(windows: FixedWindow[], startMs: number, endMs: number): number {
+  let max = 0;
+  for (const w of windows) {
+    if (w.startMs < endMs && w.endMs > startMs) max = Math.max(max, w.watts);
+  }
+  return max;
+}
+
+function buildSlots(input: PlannerInput): Slot[] {
+  const { prices, nowMs, constraintTailHours, houseLoadWattsAt, fixedSells, fixedBuys } = input;
+  const slots: Slot[] = [];
+  const relevantPrices = prices.filter(p => p.startMs + SLOT_MS > nowMs).sort((a, b) => a.startMs - b.startMs);
+  const pricedEndMs = relevantPrices.length ? relevantPrices[relevantPrices.length - 1].startMs + SLOT_MS : nowMs;
+  const tailEndMs = pricedEndMs + constraintTailHours * 3600 * 1000;
+
+  const pushSlot = (startMs: number, spot: number | undefined) => {
+    const endMs = startMs + SLOT_MS;
+    const effectiveStart = Math.max(startMs, nowMs);
+    const durationH = (endMs - effectiveStart) / 3600_000;
+    if (durationH <= 0) return;
+    const midMs = (effectiveStart + endMs) / 2;
+    slots.push({
+      startMs,
+      endMs,
+      durationH,
+      spot,
+      pvW: Math.max(0, input.solarWattsAt(midMs)),
+      houseW: Math.max(0, houseLoadWattsAt(midMs)),
+      fixedSellW: windowPowerAt(fixedSells, startMs, endMs),
+      fixedBuyW: windowPowerAt(fixedBuys, startMs, endMs),
+    });
+  };
+
+  for (const p of relevantPrices) pushSlot(p.startMs, p.spot);
+  for (let t = pricedEndMs; t < tailEndMs; t += SLOT_MS) pushSlot(t, undefined);
+  return slots;
+}
+
+type MergedWindow = { startMs: number; endMs: number; watts: number; kind: "sell" | "buy"; slotIndexes: number[] };
+
+function mergeAcceptedSlots(
+  slots: Slot[],
+  accepted: number[],
+  wattsBySlot: number[],
+  kind: "sell" | "buy",
+  min_window_minutes: number
+): {
+  windows: MergedWindow[];
+  droppedShort: number;
+} {
+  const sorted = [...accepted].sort((a, b) => a - b);
+  // Group into time-contiguous chains first: a power step mid-chain later splits into adjacent
+  // windows that are still one continuous feed, so the minimum-length rule judges whole chains.
+  const chains: number[][] = [];
+  for (const slotIndex of sorted) {
+    const lastChain = chains[chains.length - 1];
+    const previous = lastChain?.[lastChain.length - 1];
+    if (previous !== undefined && slots[slotIndex].startMs === slots[previous].endMs) lastChain.push(slotIndex);
+    else chains.push([slotIndex]);
+  }
+  const windows: MergedWindow[] = [];
+  let droppedShort = 0;
+  for (const chain of chains) {
+    const chainMinutes = (slots[chain[chain.length - 1]].endMs - slots[chain[0]].startMs) / 60000;
+    if (chainMinutes < min_window_minutes) {
+      droppedShort++;
+      continue;
+    }
+    for (const slotIndex of chain) {
+      const last = windows[windows.length - 1];
+      if (last && slots[slotIndex].startMs === last.endMs && wattsBySlot[slotIndex] === last.watts) {
+        last.endMs = slots[slotIndex].endMs;
+        last.slotIndexes.push(slotIndex);
+      } else {
+        windows.push({
+          startMs: slots[slotIndex].startMs,
+          endMs: slots[slotIndex].endMs,
+          watts: wattsBySlot[slotIndex],
+          kind,
+          slotIndexes: [slotIndex],
+        });
+      }
+    }
+  }
+  return { windows, droppedShort };
 }
 
 function emptyProjection(input: PlannerInput): PlanProjection {

--- a/backend/src/autoTrading/planner.ts
+++ b/backend/src/autoTrading/planner.ts
@@ -13,13 +13,14 @@
  * reserve). Selling energy the battery couldn't have absorbed anyway (would have auto-exported when full)
  * is naturally handled by the simulation's revenue accounting.
  *
- * Two forces keep the schedule contiguous: every sell-run start is charged sell_restart_penalty_sek in the
- * optimizer objective (objectiveSek — reported cash revenue stays clean of it), and a consolidation pass
- * (sellConsolidation.ts) defragments what the greedy scattered. The reserve floor relaxes to
- * planner_soc_floor_sunny_percent in slots where forecast PV covers the house.
+ * Fragmented schedules are allowed when they genuinely price better (a stop/start costs nothing but the
+ * modeled ramp), but a consolidation pass (sellConsolidation.ts) repairs fragmentation the greedy's
+ * accept order created for no gain, and captures fractional leftover budget as reduced-power window
+ * extensions. The reserve floor relaxes to planner_soc_floor_sunny_percent in slots where forecast PV
+ * covers the house.
  */
 
-import { objectiveSek, overlapsVeto, simulate, slotTradableForSell } from "./simulate.ts";
+import { overlapsVeto, simulate, slotTradableForSell } from "./simulate.ts";
 import { consolidateSellSlots } from "./sellConsolidation.ts";
 import type {
   FixedWindow,
@@ -72,7 +73,7 @@ export function generatePlan(input: PlannerInput): PlanResult {
   for (const { i } of sellCandidates) {
     sellW[i] = k.max_sell_power_watts;
     const trial = simulate(input, slots, sellW, buyW, tailSpot);
-    const gain = objectiveSek(trial) - objectiveSek(current);
+    const gain = trial.revenueSek - current.revenueSek;
     if (feasibleVsBase(trial) && gain >= k.min_gain_sek_per_slot) {
       current = trial;
       acceptedSell.push(i);
@@ -82,9 +83,9 @@ export function generatePlan(input: PlannerInput): PlanResult {
   }
 
   // Bridge short price valleys between accepted windows: every feed stop/start restarts the
-  // slow feed-in ramp and pays the restart penalty (both priced into the objective), so selling
-  // through a shallow dip is usually better than pausing — and nobody wants a schedule with a
-  // 30-min hole in it. Accept a bounded objective loss per bridged slot; the sim decides.
+  // slow feed-in ramp (which the simulation prices in), so selling through a shallow dip is
+  // usually better than pausing — and nobody wants a schedule with a 30-min hole in it.
+  // Accept a bounded revenue loss per bridged slot; the sim decides using ramp + prices.
   const maxGapSlots = 3;
   const maxSmoothingLossSekPerSlot = 1;
   for (let pass = 0, changed = true; pass < 4 && changed; pass++) {
@@ -107,10 +108,7 @@ export function generatePlan(input: PlannerInput): PlanResult {
       if (fillable.length !== gapSlots) continue;
       for (const j of fillable) sellW[j] = k.max_sell_power_watts;
       const trial = simulate(input, slots, sellW, buyW, tailSpot);
-      if (
-        feasibleVsBase(trial) &&
-        objectiveSek(trial) - objectiveSek(current) >= -maxSmoothingLossSekPerSlot * gapSlots
-      ) {
+      if (feasibleVsBase(trial) && trial.revenueSek - current.revenueSek >= -maxSmoothingLossSekPerSlot * gapSlots) {
         current = trial;
         acceptedSell.push(...fillable);
         changed = true;
@@ -143,7 +141,7 @@ export function generatePlan(input: PlannerInput): PlanResult {
       if (sellW[i] > 0) continue;
       buyW[i] = k.max_buy_power_watts;
       const trial = simulate(input, slots, sellW, buyW, tailSpot);
-      const gain = objectiveSek(trial) - objectiveSek(current);
+      const gain = trial.revenueSek - current.revenueSek;
       const extraBoughtKwh = (trial.boughtWh - current.boughtWh) / 1000;
       if (feasibleVsBase(trial) && extraBoughtKwh > 0 && gain / extraBoughtKwh >= k.min_buy_saving_sek_per_kwh) {
         current = trial;
@@ -209,7 +207,7 @@ export function generatePlan(input: PlannerInput): PlanResult {
         for (const b of buyGroup) buyW[b] = k.max_buy_power_watts;
         sellW[sellIdx] = k.max_sell_power_watts;
         const trial = simulate(input, slots, sellW, buyW, tailSpot);
-        const gain = objectiveSek(trial) - objectiveSek(current);
+        const gain = trial.revenueSek - current.revenueSek;
         const extraBoughtKwh = (trial.boughtWh - current.boughtWh) / 1000;
         if (feasibleVsBase(trial) && extraBoughtKwh > 0.1 && gain / extraBoughtKwh >= k.min_buy_saving_sek_per_kwh) {
           current = trial;

--- a/backend/src/autoTrading/planner.ts
+++ b/backend/src/autoTrading/planner.ts
@@ -12,6 +12,10 @@
  * down, keeping every accepted plan feasible (SOC never below the planner floor + user reserve). Selling
  * energy the battery couldn't have absorbed anyway (would have auto-exported when full) is naturally handled
  * by the simulation's revenue accounting.
+ *
+ * Two forces keep the schedule contiguous: every sell-run start is charged sell_restart_penalty_sek in the
+ * simulation, and a consolidation pass (see consolidateSellSlots) defragments what the greedy scattered.
+ * The reserve floor relaxes to planner_soc_floor_sunny_percent in slots where forecast PV covers the house.
  */
 
 import type {
@@ -68,6 +72,12 @@ function simulate(input: PlannerInput, slots: Slot[], sellW: number[], buyW: num
   const k = input.knobs;
   const cap = input.capacityWh;
   const floorPlannerWh = (k.planner_soc_floor_percent / 100) * cap + k.extra_reserve_kwh * 1000;
+  // While forecast PV covers the house, a forecast miss costs minutes of import instead of a
+  // stranded night — the reserve requirement drops accordingly (never above the normal floor).
+  const floorSunnyWh = Math.min(
+    (k.planner_soc_floor_sunny_percent / 100) * cap + k.extra_reserve_kwh * 1000,
+    floorPlannerWh
+  );
   const floorRuntimeWh = (k.runtime_soc_floor_percent / 100) * cap;
   const floorEmergencyWh = (k.emergency_soc_floor_percent / 100) * cap;
 
@@ -108,6 +118,9 @@ function simulate(input: PlannerInput, slots: Slot[], sellW: number[], buyW: num
 
     const sellingThisSlot = sellSetW > 0 && socWh > floorRuntimeWh;
     if (sellingThisSlot) {
+      // Starting a feed-in run costs more than the modeled ramp: inverter mode/relay churn,
+      // and schedules full of holes that nobody asked for. Charge each run start for it.
+      if (sellRunMinutes === 0) revenueSek -= k.sell_restart_penalty_sek;
       // Export is limited by what battery + PV can physically supply beyond the house
       // House has first dibs on the inverter's AC output; export gets the rest of the 15 kW rating
       exportW = Math.min(sellSetW, k.inverter_max_ac_output_watts - s.houseW);
@@ -163,7 +176,8 @@ function simulate(input: PlannerInput, slots: Slot[], sellW: number[], buyW: num
     importWh += slotImportWh;
     revenueSek -= (slotImportWh / 1000) * (spot + k.buy_surcharges_sek_per_kwh) * k.vat_multiplier;
 
-    if (socWh < floorPlannerWh) violationWh += floorPlannerWh - socWh;
+    const floorWh = s.pvW > s.houseW + parasiticW ? floorSunnyWh : floorPlannerWh;
+    if (socWh < floorWh) violationWh += floorWh - socWh;
     if (socWh < minSocWh) {
       minSocWh = socWh;
       minSocMs = s.endMs;
@@ -185,30 +199,225 @@ function simulate(input: PlannerInput, slots: Slot[], sellW: number[], buyW: num
   };
 }
 
+type MergedWindow = { startMs: number; endMs: number; watts: number; kind: "sell" | "buy"; slotIndexes: number[] };
+
 function mergeAcceptedSlots(
   slots: Slot[],
   accepted: number[],
-  watts: number,
+  wattsBySlot: number[],
   kind: "sell" | "buy",
   min_window_minutes: number
 ): {
-  windows: { startMs: number; endMs: number; watts: number; kind: "sell" | "buy"; slotIndexes: number[] }[];
+  windows: MergedWindow[];
   droppedShort: number;
 } {
   const sorted = [...accepted].sort((a, b) => a - b);
-  const windows: { startMs: number; endMs: number; watts: number; kind: "sell" | "buy"; slotIndexes: number[] }[] = [];
+  const windows: MergedWindow[] = [];
   for (const i of sorted) {
     const last = windows[windows.length - 1];
-    if (last && slots[i].startMs === last.endMs) {
+    if (last && slots[i].startMs === last.endMs && wattsBySlot[i] === last.watts) {
       last.endMs = slots[i].endMs;
       last.slotIndexes.push(i);
     } else {
-      windows.push({ startMs: slots[i].startMs, endMs: slots[i].endMs, watts, kind, slotIndexes: [i] });
+      windows.push({ startMs: slots[i].startMs, endMs: slots[i].endMs, watts: wattsBySlot[i], kind, slotIndexes: [i] });
     }
   }
-  const before = windows.length;
-  const kept = windows.filter(w => (w.endMs - w.startMs) / 60000 >= min_window_minutes);
-  return { windows: kept, droppedShort: before - kept.length };
+  // A power step mid-run splits into adjacent windows that are still one continuous feed —
+  // the minimum-length rule judges the whole contiguous chain, not each window.
+  const chains: MergedWindow[][] = [];
+  for (const w of windows) {
+    const lastChain = chains[chains.length - 1];
+    if (lastChain && lastChain[lastChain.length - 1].endMs === w.startMs) lastChain.push(w);
+    else chains.push([w]);
+  }
+  const kept: MergedWindow[] = [];
+  let droppedShort = 0;
+  for (const chain of chains) {
+    const chainMinutes = (chain[chain.length - 1].endMs - chain[0].startMs) / 60000;
+    if (chainMinutes >= min_window_minutes) kept.push(...chain);
+    else droppedShort += chain.length;
+  }
+  return { windows: kept, droppedShort };
+}
+
+/**
+ * Defragment the greedy's sell allocation. Under a binding reserve budget the greedy takes the
+ * top-priced 15-min slots, which zigzagging 15-min prices scatter into combs — and the ramp model
+ * amplifies that: near budget exhaustion a full-power contiguous slot no longer fits while an
+ * isolated (ramp-crippled, ~2/3 energy) slot still does, so holes win systematically. Local-search
+ * moves repair this, each re-simulated and only applied when feasible and simulated revenue
+ * improves (the restart penalty is what tips consolidation into "improves"):
+ *   - fill a one-slot hole between runs, alone (full or reduced power) or funded by dropping the
+ *     cheapest edge slot of another run
+ *   - merge two neighbouring runs by relocating the smaller flush against the larger (covers
+ *     single-slot teeth as the degenerate case) — öre of price cost against whole SEK of penalty
+ *   - extend a run edge at reduced power, so a fractional leftover budget still gets sold instead
+ *     of spawning a remote ramp-crippled tooth (pure adds must clear min_gain_sek_per_slot and the
+ *     min sell spot, like the greedy's adds)
+ * Mutates sellW in place; returns the simulation state it converged on.
+ */
+function consolidateSellSlots(
+  input: PlannerInput,
+  slots: Slot[],
+  sellW: number[],
+  buyW: number[],
+  tailSpot: number,
+  feasible: (r: SimResult) => boolean,
+  current: SimResult
+): SimResult {
+  const k = input.knobs;
+  const fillable = (j: number) =>
+    j >= 0 &&
+    j < slots.length &&
+    sellW[j] === 0 &&
+    buyW[j] === 0 &&
+    slots[j].spot !== undefined &&
+    slots[j].fixedSellW === 0 &&
+    slots[j].fixedBuyW === 0 &&
+    !input.sellVetoWindows.some(v => v.startMs < slots[j].endMs && v.endMs > slots[j].startMs);
+  const timeAdjacent = (i: number, j: number) =>
+    slots[i] !== undefined && slots[j] !== undefined && slots[j].startMs === slots[i].endMs;
+
+  const computeRuns = () => {
+    const runs: number[][] = [];
+    for (let i = 0; i < slots.length; i++) {
+      if (sellW[i] <= 0) continue;
+      const lastRun = runs[runs.length - 1];
+      const prev = lastRun?.[lastRun.length - 1];
+      if (prev !== undefined && timeAdjacent(prev, i)) lastRun.push(i);
+      else runs.push([i]);
+    }
+    return runs;
+  };
+
+  let trialsLeft = 400;
+  const accept = (minGainSek: number): boolean => {
+    if (trialsLeft-- <= 0) return false;
+    const trial = simulate(input, slots, sellW, buyW, tailSpot);
+    if (feasible(trial) && trial.revenueSek > current.revenueSek + Math.max(minGainSek, 1e-6)) {
+      current = trial;
+      return true;
+    }
+    return false;
+  };
+
+  // Add one slot (full power first, reduced captures fractional budgets), optionally funded by
+  // dropping another. Funded moves are ~energy-neutral and need no extra gain; pure adds clear
+  // the same min-gain bar as the greedy's.
+  const tryFill = (dropIdx: number | undefined, addIdx: number): boolean => {
+    const savedDrop = dropIdx !== undefined ? sellW[dropIdx] : 0;
+    if (dropIdx !== undefined) sellW[dropIdx] = 0;
+    for (const factor of [1, 2 / 3, 1 / 2, 1 / 3]) {
+      sellW[addIdx] = Math.round(k.max_sell_power_watts * factor);
+      if (accept(dropIdx === undefined ? k.min_gain_sek_per_slot : 0)) return true;
+    }
+    sellW[addIdx] = 0;
+    if (dropIdx !== undefined) sellW[dropIdx] = savedDrop;
+    return false;
+  };
+
+  // Relocate a whole run onto a target position. The move changes ramp state (e.g. a crippled
+  // isolated slot becomes a full-power run member), so scaled-down watts are also tried — that
+  // lets an energy-equivalent relocation through a binding budget.
+  const tryRelocateRun = (run: number[], targets: number[]): boolean => {
+    const savedWatts = run.map(i => sellW[i]);
+    for (const i of run) sellW[i] = 0;
+    if (targets.every(fillable)) {
+      for (const factor of [1, 2 / 3, 1 / 2, 1 / 3]) {
+        targets.forEach((j, idx) => (sellW[j] = Math.round(savedWatts[idx] * factor)));
+        if (accept(0)) return true;
+      }
+      for (const j of targets) sellW[j] = 0;
+    }
+    run.forEach((i, idx) => (sellW[i] = savedWatts[idx]));
+    return false;
+  };
+
+  let movesLeft = 24;
+  outer: while (movesLeft-- > 0 && trialsLeft > 0) {
+    const runs = computeRuns();
+    if (!runs.length) break;
+
+    // 1. One-slot holes between consecutive runs: fill, else fund by dropping the cheapest edge
+    //    slot of some run (never a slot adjacent to the hole — that just moves it)
+    const edges = runs
+      .flatMap(run => (run.length === 1 ? [run[0]] : [run[0], run[run.length - 1]]))
+      .sort((a, b) => (slots[a].spot ?? 0) - (slots[b].spot ?? 0));
+    for (let runIdx = 0; runIdx + 1 < runs.length; runIdx++) {
+      const hole = runs[runIdx][runs[runIdx].length - 1] + 1;
+      if (runs[runIdx + 1][0] !== hole + 1 || !fillable(hole)) continue;
+      if (!timeAdjacent(hole - 1, hole) || !timeAdjacent(hole, hole + 1)) continue;
+      if (tryFill(undefined, hole)) continue outer;
+      for (const edge of edges) {
+        if (Math.abs(edge - hole) <= 1) continue;
+        if (tryFill(edge, hole)) continue outer;
+      }
+    }
+
+    // 2. Merge neighbouring runs by relocating one flush against the other. Try the cheaper
+    //    relocation (fewer slots moved) first, then the reverse.
+    for (let runIdx = 0; runIdx + 1 < runs.length; runIdx++) {
+      const before = runs[runIdx];
+      const after = runs[runIdx + 1];
+      if (after[0] - before[before.length - 1] < 2) continue;
+      // A run relocated flush against the other: target indexes + the anchor slot they must touch
+      const flushRight = (moved: number[]) => ({
+        moved,
+        targets: moved.map((_, idx) => after[0] - moved.length + idx),
+        anchor: after[0],
+      });
+      const flushLeft = (moved: number[]) => ({
+        moved,
+        targets: moved.map((_, idx) => before[before.length - 1] + 1 + idx),
+        anchor: before[before.length - 1],
+      });
+      const attempts =
+        before.length <= after.length ? [flushRight(before), flushLeft(after)] : [flushLeft(after), flushRight(before)];
+      for (const { moved, targets, anchor } of attempts) {
+        const chain = [...targets, anchor].sort((a, b) => a - b);
+        if (!chain.every((idx, pos) => pos === 0 || timeAdjacent(chain[pos - 1], idx))) continue;
+        if (tryRelocateRun(moved, targets)) continue outer;
+      }
+    }
+
+    // 3. Extend run edges at reduced power — mops up a leftover budget fraction
+    for (const run of runs) {
+      const first = run[0];
+      const last = run[run.length - 1];
+      for (const target of [first - 1, last + 1]) {
+        if (!fillable(target)) continue;
+        if (!(target < first ? timeAdjacent(target, first) : timeAdjacent(last, target))) continue;
+        if ((slots[target].spot ?? 0) < k.min_sell_spot_sek_per_kwh) continue;
+        if (tryFill(undefined, target)) continue outer;
+      }
+    }
+    break;
+  }
+
+  // Finally, equalize power across each chain's post-ramp body: same energy (mean rounded down),
+  // ± öre of revenue, and the schedule collapses to a couple of entries instead of the power
+  // staircase reduced-power fills leave behind. Slots still inside the ramp window keep their
+  // power — the ramp caps their export, so averaging power away from them loses real energy.
+  for (const run of computeRuns()) {
+    let offsetMinutes = 0;
+    const body: number[] = [];
+    for (const i of run) {
+      if (offsetMinutes >= k.sell_ramp_minutes) body.push(i);
+      offsetMinutes += slots[i].durationH * 60;
+    }
+    if (body.length < 2 || new Set(body.map(i => sellW[i])).size <= 1) continue;
+    if (trialsLeft-- <= 0) break;
+    const savedWatts = body.map(i => sellW[i]);
+    const meanWatts = Math.floor(savedWatts.reduce((a, b) => a + b, 0) / body.length / 100) * 100;
+    for (const i of body) sellW[i] = meanWatts;
+    const trial = simulate(input, slots, sellW, buyW, tailSpot);
+    if (feasible(trial) && trial.revenueSek >= current.revenueSek - 0.1 * body.length) {
+      current = trial;
+    } else {
+      body.forEach((i, idx) => (sellW[i] = savedWatts[idx]));
+    }
+  }
+  return current;
 }
 
 export function generatePlan(input: PlannerInput): PlanResult {
@@ -310,6 +519,12 @@ export function generatePlan(input: PlannerInput): PlanResult {
       }
     }
   }
+
+  // Defragment what the greedy scattered (see consolidateSellSlots) — sellW is the source of
+  // truth afterwards, so rebuild the accepted list from it
+  current = consolidateSellSlots(input, slots, sellW, buyW, tailSpot, feasibleVsBase, current);
+  acceptedSell.length = 0;
+  for (let i = 0; i < slots.length; i++) if (sellW[i] > 0) acceptedSell.push(i);
 
   // ---- Buy allocation, pass 1: avert projected unavoidable imports, cheapest slots first ----
   const acceptedBuy: number[] = [];
@@ -431,7 +646,7 @@ export function generatePlan(input: PlannerInput): PlanResult {
   const { windows: sellWindows, droppedShort } = mergeAcceptedSlots(
     slots,
     acceptedSell,
-    k.max_sell_power_watts,
+    sellW,
     "sell",
     k.min_window_minutes
   );
@@ -443,13 +658,7 @@ export function generatePlan(input: PlannerInput): PlanResult {
     current = simulate(input, slots, sellW, buyW, tailSpot);
   }
 
-  const { windows: buyWindows } = mergeAcceptedSlots(
-    slots,
-    acceptedBuy,
-    k.max_buy_power_watts,
-    "buy",
-    k.min_window_minutes
-  );
+  const { windows: buyWindows } = mergeAcceptedSlots(slots, acceptedBuy, buyW, "buy", k.min_window_minutes);
 
   // ---- Package result ----
   const spotsAll = pricedSlots.map(s => s.spot!).sort((a, b) => a - b);

--- a/backend/src/autoTrading/planner.types.ts
+++ b/backend/src/autoTrading/planner.types.ts
@@ -92,7 +92,10 @@ export type Slot = {
   fixedBuyW: number;
 };
 export type SimResult = {
+  /** Cash revenue projection (fees included, restart penalty NOT — comparable to settled reality) */
   revenueSek: number;
+  /** Fictional churn charge per sell-run start; the optimizer maximizes revenueSek − restartPenaltySek */
+  restartPenaltySek: number;
   violationWh: number;
   minSocWh: number;
   minSocMs: number;

--- a/backend/src/autoTrading/planner.types.ts
+++ b/backend/src/autoTrading/planner.types.ts
@@ -12,6 +12,7 @@ export type PlannerKnobs = Pick<
   | "inverter_max_ac_output_watts"
   | "max_buy_power_watts"
   | "planner_soc_floor_percent"
+  | "planner_soc_floor_sunny_percent"
   | "emergency_soc_floor_percent"
   | "extra_reserve_kwh"
   | "min_sell_spot_sek_per_kwh"
@@ -24,6 +25,7 @@ export type PlannerKnobs = Pick<
   | "sell_bonus_sek_per_kwh"
   | "min_buy_saving_sek_per_kwh"
   | "sell_ramp_minutes"
+  | "sell_restart_penalty_sek"
   | "allow_arbitrage_buying"
 > & {
   /** scheduled_power_selling.only_sell_above_soc — where the runtime cuts selling off */

--- a/backend/src/autoTrading/planner.types.ts
+++ b/backend/src/autoTrading/planner.types.ts
@@ -25,7 +25,6 @@ export type PlannerKnobs = Pick<
   | "sell_bonus_sek_per_kwh"
   | "min_buy_saving_sek_per_kwh"
   | "sell_ramp_minutes"
-  | "sell_restart_penalty_sek"
   | "allow_arbitrage_buying"
 > & {
   /** scheduled_power_selling.only_sell_above_soc — where the runtime cuts selling off */
@@ -92,10 +91,7 @@ export type Slot = {
   fixedBuyW: number;
 };
 export type SimResult = {
-  /** Cash revenue projection (fees included, restart penalty NOT — comparable to settled reality) */
   revenueSek: number;
-  /** Fictional churn charge per sell-run start; the optimizer maximizes revenueSek − restartPenaltySek */
-  restartPenaltySek: number;
   violationWh: number;
   minSocWh: number;
   minSocMs: number;

--- a/backend/src/autoTrading/sellConsolidation.ts
+++ b/backend/src/autoTrading/sellConsolidation.ts
@@ -190,10 +190,13 @@ function tryRelocateRun(search: SearchState, run: number[], targets: number[]): 
 }
 
 /**
- * Equalize power across each chain's post-ramp body: same energy (mean rounded down), ± öre of
- * revenue, and the schedule collapses to a couple of entries instead of the power staircase
- * reduced-power fills leave behind. Slots still inside the ramp window keep their power — the
- * ramp caps their export, so averaging power away from them loses real energy.
+ * Equalize power across each chain's post-ramp body: same energy (mean rounded to the nearest
+ * 100 W, so rounding costs at most ±öre), and the schedule collapses to a couple of entries
+ * instead of the power staircase reduced-power fills leave behind. Purely cosmetic, so the
+ * accepted objective loss is capped flat at 0.1 SEK regardless of chain length — a chain whose
+ * internal price gradient makes equal power genuinely costlier keeps its staircase. Slots still
+ * inside the ramp window keep their power — the ramp caps their export, so averaging power away
+ * from them loses real energy.
  */
 function equalizeChainPower(search: SearchState) {
   for (const run of computeRuns(search)) {
@@ -206,10 +209,10 @@ function equalizeChainPower(search: SearchState) {
     if (body.length < 2 || new Set(body.map(slotIndex => search.sellW[slotIndex])).size <= 1) continue;
     if (search.trialsLeft-- <= 0) break;
     const savedWatts = body.map(slotIndex => search.sellW[slotIndex]);
-    const meanWatts = Math.floor(savedWatts.reduce((a, b) => a + b, 0) / body.length / 100) * 100;
+    const meanWatts = Math.round(savedWatts.reduce((a, b) => a + b, 0) / body.length / 100) * 100;
     for (const slotIndex of body) search.sellW[slotIndex] = meanWatts;
     const trial = simulate(search.input, search.slots, search.sellW, search.buyW, search.tailSpot);
-    if (search.feasible(trial) && objectiveSek(trial) >= objectiveSek(search.current) - 0.1 * body.length) {
+    if (search.feasible(trial) && objectiveSek(trial) >= objectiveSek(search.current) - 0.1) {
       search.current = trial;
     } else {
       body.forEach((slotIndex, offset) => (search.sellW[slotIndex] = savedWatts[offset]));

--- a/backend/src/autoTrading/sellConsolidation.ts
+++ b/backend/src/autoTrading/sellConsolidation.ts
@@ -1,25 +1,24 @@
 /**
- * Defragment the greedy's sell allocation (called by generatePlan after the bridge pass).
- *
- * Why it exists: under a binding reserve budget the greedy takes the top-priced 15-min slots,
- * which zigzagging 15-min day-ahead prices scatter into combs — and the ramp model amplifies
- * that: near budget exhaustion a full-power contiguous slot no longer fits while an isolated
- * (ramp-crippled, ~2/3 energy) slot still does, so holes win systematically (the "15 min Loch"
- * schedules of 2026-07-07/08). Local-search moves repair this; each is re-simulated and only
- * applied when feasible and the optimizer objective (revenue minus restart penalties) improves:
+ * Local-search cleanup of the greedy's sell allocation (called by generatePlan after the bridge
+ * pass). A fragmented schedule is fine when it genuinely prices better — a stop/start costs
+ * nothing but the modeled ramp — but the greedy's one-slot-at-a-time accept order also strands
+ * revenue it can't see: a hole whose fill would recover a ramp restart, a scattered slot that a
+ * relocation turns into full-power run time, and fractional leftover budget no full-power slot
+ * fits. Each move below is re-simulated and only applied when feasible and simulated revenue
+ * strictly improves (plus one öre-capped cosmetic pass):
  *   - fill a one-slot hole between runs, alone (full or reduced power) or funded by dropping the
  *     cheapest edge slot of another run. Like the pre-existing bridge pass, fills may cross a
- *     below-min-spot dip — the simulation prices that against the reclaimed restart penalty.
+ *     below-min-spot dip — the simulation prices the dip against the recovered ramp.
  *   - merge two neighbouring runs by relocating one flush against the other (covers single-slot
- *     teeth as the degenerate case) — öre of price cost against whole SEK of penalty
+ *     teeth as the degenerate case) when the ramp recovery beats the price difference
  *   - extend a run edge at reduced power, so a fractional leftover budget still gets sold instead
  *     of spawning a remote ramp-crippled tooth (pure edge adds must clear min_gain_sek_per_slot
  *     and the min sell spot, like the greedy's adds)
  * plus a final cosmetic pass that equalizes power across each chain's post-ramp body so the
- * schedule collapses to a couple of entries instead of a power staircase.
+ * schedule collapses to a couple of entries instead of a power staircase (≤ 0.1 SEK tolerated).
  */
 
-import { objectiveSek, simulate, slotTradableForSell } from "./simulate.ts";
+import { simulate, slotTradableForSell } from "./simulate.ts";
 import type { PlannerInput, SimResult, Slot } from "./planner.types.ts";
 
 /**
@@ -142,11 +141,11 @@ function timeAdjacent(search: SearchState, earlier: number, later: number): bool
   return earlierSlot !== undefined && laterSlot !== undefined && laterSlot.startMs === earlierSlot.endMs;
 }
 
-/** Simulate the current sellW; keep it (and return true) when feasible and the objective improves enough. */
+/** Simulate the current sellW; keep it (and return true) when feasible and revenue improves enough. */
 function acceptTrial(search: SearchState, minGainSek: number): boolean {
   if (search.trialsLeft-- <= 0) return false;
   const trial = simulate(search.input, search.slots, search.sellW, search.buyW, search.tailSpot);
-  if (search.feasible(trial) && objectiveSek(trial) > objectiveSek(search.current) + Math.max(minGainSek, 1e-6)) {
+  if (search.feasible(trial) && trial.revenueSek > search.current.revenueSek + Math.max(minGainSek, 1e-6)) {
     search.current = trial;
     return true;
   }
@@ -193,7 +192,7 @@ function tryRelocateRun(search: SearchState, run: number[], targets: number[]): 
  * Equalize power across each chain's post-ramp body: same energy (mean rounded to the nearest
  * 100 W, so rounding costs at most ±öre), and the schedule collapses to a couple of entries
  * instead of the power staircase reduced-power fills leave behind. Purely cosmetic, so the
- * accepted objective loss is capped flat at 0.1 SEK regardless of chain length — a chain whose
+ * accepted revenue loss is capped flat at 0.1 SEK regardless of chain length — a chain whose
  * internal price gradient makes equal power genuinely costlier keeps its staircase. Slots still
  * inside the ramp window keep their power — the ramp caps their export, so averaging power away
  * from them loses real energy.
@@ -212,7 +211,7 @@ function equalizeChainPower(search: SearchState) {
     const meanWatts = Math.round(savedWatts.reduce((a, b) => a + b, 0) / body.length / 100) * 100;
     for (const slotIndex of body) search.sellW[slotIndex] = meanWatts;
     const trial = simulate(search.input, search.slots, search.sellW, search.buyW, search.tailSpot);
-    if (search.feasible(trial) && objectiveSek(trial) >= objectiveSek(search.current) - 0.1) {
+    if (search.feasible(trial) && trial.revenueSek >= search.current.revenueSek - 0.1) {
       search.current = trial;
     } else {
       body.forEach((slotIndex, offset) => (search.sellW[slotIndex] = savedWatts[offset]));

--- a/backend/src/autoTrading/sellConsolidation.ts
+++ b/backend/src/autoTrading/sellConsolidation.ts
@@ -1,0 +1,218 @@
+/**
+ * Defragment the greedy's sell allocation (called by generatePlan after the bridge pass).
+ *
+ * Why it exists: under a binding reserve budget the greedy takes the top-priced 15-min slots,
+ * which zigzagging 15-min day-ahead prices scatter into combs — and the ramp model amplifies
+ * that: near budget exhaustion a full-power contiguous slot no longer fits while an isolated
+ * (ramp-crippled, ~2/3 energy) slot still does, so holes win systematically (the "15 min Loch"
+ * schedules of 2026-07-07/08). Local-search moves repair this; each is re-simulated and only
+ * applied when feasible and the optimizer objective (revenue minus restart penalties) improves:
+ *   - fill a one-slot hole between runs, alone (full or reduced power) or funded by dropping the
+ *     cheapest edge slot of another run. Like the pre-existing bridge pass, fills may cross a
+ *     below-min-spot dip — the simulation prices that against the reclaimed restart penalty.
+ *   - merge two neighbouring runs by relocating one flush against the other (covers single-slot
+ *     teeth as the degenerate case) — öre of price cost against whole SEK of penalty
+ *   - extend a run edge at reduced power, so a fractional leftover budget still gets sold instead
+ *     of spawning a remote ramp-crippled tooth (pure edge adds must clear min_gain_sek_per_slot
+ *     and the min sell spot, like the greedy's adds)
+ * plus a final cosmetic pass that equalizes power across each chain's post-ramp body so the
+ * schedule collapses to a couple of entries instead of a power staircase.
+ */
+
+import { objectiveSek, simulate, slotTradableForSell } from "./simulate.ts";
+import type { PlannerInput, SimResult, Slot } from "./planner.types.ts";
+
+/**
+ * Shared mutable state of the local search. Helpers mutate sellW (the candidate schedule),
+ * current (the accepted simulation) and trialsLeft (the simulate-call budget) through this —
+ * explicit at every call site instead of hidden in closures.
+ */
+type SearchState = {
+  input: PlannerInput;
+  slots: Slot[];
+  sellW: number[];
+  buyW: number[];
+  tailSpot: number;
+  feasible: (result: SimResult) => boolean;
+  current: SimResult;
+  trialsLeft: number;
+};
+
+/** Mutates sellW in place; returns the simulation state it converged on. */
+export function consolidateSellSlots(
+  input: PlannerInput,
+  slots: Slot[],
+  sellW: number[],
+  buyW: number[],
+  tailSpot: number,
+  feasible: (result: SimResult) => boolean,
+  current: SimResult
+): SimResult {
+  const search: SearchState = { input, slots, sellW, buyW, tailSpot, feasible, current, trialsLeft: 400 };
+  const { min_sell_spot_sek_per_kwh } = input.knobs;
+
+  let movesLeft = 24;
+  outer: while (movesLeft-- > 0 && search.trialsLeft > 0) {
+    const runs = computeRuns(search);
+    if (!runs.length) break;
+
+    // 1. One-slot holes between consecutive runs: fill, else fund by dropping the cheapest edge
+    //    slot of some run (never a slot adjacent to the hole — that just moves it)
+    const edges = runs
+      .flatMap(run => (run.length === 1 ? [run[0]] : [run[0], run[run.length - 1]]))
+      .sort((a, b) => (slots[a].spot ?? 0) - (slots[b].spot ?? 0));
+    for (let runIdx = 0; runIdx + 1 < runs.length; runIdx++) {
+      const hole = runs[runIdx][runs[runIdx].length - 1] + 1;
+      if (runs[runIdx + 1][0] !== hole + 1 || !fillableSlot(search, hole)) continue;
+      if (!timeAdjacent(search, hole - 1, hole) || !timeAdjacent(search, hole, hole + 1)) continue;
+      if (tryFill(search, undefined, hole)) continue outer;
+      for (const edge of edges) {
+        if (Math.abs(edge - hole) <= 1) continue;
+        if (tryFill(search, edge, hole)) continue outer;
+      }
+    }
+
+    // 2. Merge neighbouring runs by relocating one flush against the other — cheaper relocation
+    //    (fewer slots moved) first
+    for (let runIdx = 0; runIdx + 1 < runs.length; runIdx++) {
+      const before = runs[runIdx];
+      const after = runs[runIdx + 1];
+      const beforeEnd = before[before.length - 1];
+      if (after[0] - beforeEnd < 2) continue;
+      // A flush relocation only exists when the whole span sits on one uninterrupted 15-min grid
+      let spanContiguous = true;
+      for (let idx = beforeEnd; idx < after[0] && spanContiguous; idx++) {
+        spanContiguous = timeAdjacent(search, idx, idx + 1);
+      }
+      if (!spanContiguous) continue;
+      const attempts = [
+        { moved: before, targets: before.map((_, offset) => after[0] - before.length + offset) },
+        { moved: after, targets: after.map((_, offset) => beforeEnd + 1 + offset) },
+      ].sort((a, b) => a.moved.length - b.moved.length);
+      for (const { moved, targets } of attempts) {
+        if (tryRelocateRun(search, moved, targets)) continue outer;
+      }
+    }
+
+    // 3. Extend run edges at reduced power — mops up a leftover budget fraction
+    for (const run of runs) {
+      const first = run[0];
+      const last = run[run.length - 1];
+      for (const target of [first - 1, last + 1]) {
+        if (!fillableSlot(search, target)) continue;
+        if (!(target < first ? timeAdjacent(search, target, first) : timeAdjacent(search, last, target))) continue;
+        if ((slots[target].spot ?? 0) < min_sell_spot_sek_per_kwh) continue;
+        if (tryFill(search, undefined, target)) continue outer;
+      }
+    }
+    break;
+  }
+
+  equalizeChainPower(search);
+  return search.current;
+}
+
+/** Contiguous runs of accepted sell slots, ascending in time. */
+function computeRuns(search: SearchState): number[][] {
+  const runs: number[][] = [];
+  for (let slotIndex = 0; slotIndex < search.slots.length; slotIndex++) {
+    if (search.sellW[slotIndex] <= 0) continue;
+    const lastRun = runs[runs.length - 1];
+    const previous = lastRun?.[lastRun.length - 1];
+    if (previous !== undefined && timeAdjacent(search, previous, slotIndex)) lastRun.push(slotIndex);
+    else runs.push([slotIndex]);
+  }
+  return runs;
+}
+
+/** May the search put NEW selling into this slot? */
+function fillableSlot(search: SearchState, slotIndex: number): boolean {
+  const slot = search.slots[slotIndex];
+  return (
+    slot !== undefined &&
+    search.sellW[slotIndex] === 0 &&
+    search.buyW[slotIndex] === 0 &&
+    slotTradableForSell(slot, search.input.sellVetoWindows)
+  );
+}
+
+function timeAdjacent(search: SearchState, earlier: number, later: number): boolean {
+  const earlierSlot = search.slots[earlier];
+  const laterSlot = search.slots[later];
+  return earlierSlot !== undefined && laterSlot !== undefined && laterSlot.startMs === earlierSlot.endMs;
+}
+
+/** Simulate the current sellW; keep it (and return true) when feasible and the objective improves enough. */
+function acceptTrial(search: SearchState, minGainSek: number): boolean {
+  if (search.trialsLeft-- <= 0) return false;
+  const trial = simulate(search.input, search.slots, search.sellW, search.buyW, search.tailSpot);
+  if (search.feasible(trial) && objectiveSek(trial) > objectiveSek(search.current) + Math.max(minGainSek, 1e-6)) {
+    search.current = trial;
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Add one slot (full power first, reduced captures fractional budgets), optionally funded by
+ * dropping another. Funded moves are ~energy-neutral and need no extra gain; pure adds clear the
+ * same min-gain bar as the greedy's.
+ */
+function tryFill(search: SearchState, dropIndex: number | undefined, addIndex: number): boolean {
+  const savedDropWatts = dropIndex !== undefined ? search.sellW[dropIndex] : 0;
+  if (dropIndex !== undefined) search.sellW[dropIndex] = 0;
+  for (const factor of [1, 2 / 3, 1 / 2, 1 / 3]) {
+    search.sellW[addIndex] = Math.round(search.input.knobs.max_sell_power_watts * factor);
+    if (acceptTrial(search, dropIndex === undefined ? search.input.knobs.min_gain_sek_per_slot : 0)) return true;
+  }
+  search.sellW[addIndex] = 0;
+  if (dropIndex !== undefined) search.sellW[dropIndex] = savedDropWatts;
+  return false;
+}
+
+/**
+ * Relocate a whole run onto a target position. The move changes ramp state (e.g. a crippled
+ * isolated slot becomes a full-power run member), so scaled-down watts are also tried — that
+ * lets an energy-equivalent relocation through a binding budget.
+ */
+function tryRelocateRun(search: SearchState, run: number[], targets: number[]): boolean {
+  const savedWatts = run.map(slotIndex => search.sellW[slotIndex]);
+  for (const slotIndex of run) search.sellW[slotIndex] = 0;
+  if (targets.every(target => fillableSlot(search, target))) {
+    for (const factor of [1, 2 / 3, 1 / 2, 1 / 3]) {
+      targets.forEach((target, offset) => (search.sellW[target] = Math.round(savedWatts[offset] * factor)));
+      if (acceptTrial(search, 0)) return true;
+    }
+    for (const target of targets) search.sellW[target] = 0;
+  }
+  run.forEach((slotIndex, offset) => (search.sellW[slotIndex] = savedWatts[offset]));
+  return false;
+}
+
+/**
+ * Equalize power across each chain's post-ramp body: same energy (mean rounded down), ± öre of
+ * revenue, and the schedule collapses to a couple of entries instead of the power staircase
+ * reduced-power fills leave behind. Slots still inside the ramp window keep their power — the
+ * ramp caps their export, so averaging power away from them loses real energy.
+ */
+function equalizeChainPower(search: SearchState) {
+  for (const run of computeRuns(search)) {
+    let offsetMinutes = 0;
+    const body: number[] = [];
+    for (const slotIndex of run) {
+      if (offsetMinutes >= search.input.knobs.sell_ramp_minutes) body.push(slotIndex);
+      offsetMinutes += search.slots[slotIndex].durationH * 60;
+    }
+    if (body.length < 2 || new Set(body.map(slotIndex => search.sellW[slotIndex])).size <= 1) continue;
+    if (search.trialsLeft-- <= 0) break;
+    const savedWatts = body.map(slotIndex => search.sellW[slotIndex]);
+    const meanWatts = Math.floor(savedWatts.reduce((a, b) => a + b, 0) / body.length / 100) * 100;
+    for (const slotIndex of body) search.sellW[slotIndex] = meanWatts;
+    const trial = simulate(search.input, search.slots, search.sellW, search.buyW, search.tailSpot);
+    if (search.feasible(trial) && objectiveSek(trial) >= objectiveSek(search.current) - 0.1 * body.length) {
+      search.current = trial;
+    } else {
+      body.forEach((slotIndex, offset) => (search.sellW[slotIndex] = savedWatts[offset]));
+    }
+  }
+}

--- a/backend/src/autoTrading/simulate.ts
+++ b/backend/src/autoTrading/simulate.ts
@@ -28,7 +28,6 @@ export function simulate(
 
   let socWh = (input.socPercent / 100) * cap;
   let revenueSek = 0;
-  let restartPenaltySek = 0;
   let violationWh = 0;
   let minSocWh = socWh;
   let minSocMs = input.nowMs;
@@ -64,11 +63,6 @@ export function simulate(
 
     const sellingThisSlot = sellSetW > 0 && socWh > floorRuntimeWh;
     if (sellingThisSlot) {
-      // Starting a feed-in run costs more than the modeled ramp: inverter mode/relay churn, and
-      // schedules full of holes that nobody asked for. Tracked separately from revenueSek so the
-      // optimizer can charge for it (see objectiveSek) while the reported cash projection stays
-      // comparable to settled reality (tradingPerformance.ts).
-      if (sellRunMinutes === 0) restartPenaltySek += k.sell_restart_penalty_sek;
       // Export is limited by what battery + PV can physically supply beyond the house
       // House has first dibs on the inverter's AC output; export gets the rest of the 15 kW rating
       exportW = Math.min(sellSetW, k.inverter_max_ac_output_watts - s.houseW);
@@ -135,7 +129,6 @@ export function simulate(
 
   return {
     revenueSek,
-    restartPenaltySek,
     violationWh,
     minSocWh,
     minSocMs,
@@ -146,14 +139,6 @@ export function simulate(
     boughtWh,
     socAfterSlot,
   };
-}
-
-/**
- * What the optimizer maximizes: cash revenue minus the (fictional) restart penalty. Every accept
- * decision compares this; every user-facing projection reports plain revenueSek instead.
- */
-export function objectiveSek(result: SimResult): number {
-  return result.revenueSek - result.restartPenaltySek;
 }
 
 export function overlapsVeto(

--- a/backend/src/autoTrading/simulate.ts
+++ b/backend/src/autoTrading/simulate.ts
@@ -1,0 +1,175 @@
+/**
+ * The planner's battery/revenue simulation core: replay a candidate schedule (per-slot sell/buy
+ * setpoints + fixed windows) over the forecast horizon and report revenue, floor violations and
+ * the SOC trajectory. Shared by the greedy allocation in planner.ts and the local search in
+ * sellConsolidation.ts, which is why it lives in its own module.
+ */
+
+import type { PlannerInput, SimResult, Slot } from "./planner.types.ts";
+
+export function simulate(
+  input: PlannerInput,
+  slots: Slot[],
+  sellW: number[],
+  buyW: number[],
+  tailSpot: number
+): SimResult {
+  const k = input.knobs;
+  const cap = input.capacityWh;
+  const floorPlannerWh = (k.planner_soc_floor_percent / 100) * cap + k.extra_reserve_kwh * 1000;
+  // While forecast PV covers the house, a forecast miss costs minutes of import instead of a
+  // stranded night — the reserve requirement drops accordingly (never above the normal floor).
+  const floorSunnyWh = Math.min(
+    (k.planner_soc_floor_sunny_percent / 100) * cap + k.extra_reserve_kwh * 1000,
+    floorPlannerWh
+  );
+  const floorRuntimeWh = (k.runtime_soc_floor_percent / 100) * cap;
+  const floorEmergencyWh = (k.emergency_soc_floor_percent / 100) * cap;
+
+  let socWh = (input.socPercent / 100) * cap;
+  let revenueSek = 0;
+  let restartPenaltySek = 0;
+  let violationWh = 0;
+  let minSocWh = socWh;
+  let minSocMs = input.nowMs;
+  let sellExportWh = 0;
+  let autoExportWh = 0;
+  let importWh = 0;
+  let boughtWh = 0;
+  const socAfterSlot: number[] = new Array(slots.length);
+  // Minutes of continuous selling so far — the inverter ramps grid feed-in slowly (grid safety),
+  // so the first sell_ramp_minutes of every (re)start deliver reduced power.
+  let sellRunMinutes = 0;
+
+  for (let i = 0; i < slots.length; i++) {
+    const s = slots[i];
+    const spot = s.spot ?? tailSpot;
+    const parasiticW = input.parasiticWatts;
+    const sellSetW = Math.max(sellW[i], s.fixedSellW);
+    const requestedBuyW = Math.max(buyW[i], s.fixedBuyW);
+    // Runtime never does both at once (feedWhenNoSolar errors out) — selling wins in our model
+    const buySetW = sellSetW > 0 ? 0 : requestedBuyW;
+
+    let exportW = 0;
+    let gridChargeW = 0;
+    let slotImportWh = 0;
+
+    if (buySetW > 0 && socWh < cap * 0.98) {
+      // AC charging: battery charges from grid, house is fed from grid too
+      gridChargeW = buySetW;
+      slotImportWh +=
+        (buySetW + s.houseW + parasiticW - Math.min(s.pvW, buySetW + s.houseW + parasiticW)) * s.durationH;
+      boughtWh += buySetW * s.durationH;
+    }
+
+    const sellingThisSlot = sellSetW > 0 && socWh > floorRuntimeWh;
+    if (sellingThisSlot) {
+      // Starting a feed-in run costs more than the modeled ramp: inverter mode/relay churn, and
+      // schedules full of holes that nobody asked for. Tracked separately from revenueSek so the
+      // optimizer can charge for it (see objectiveSek) while the reported cash projection stays
+      // comparable to settled reality (tradingPerformance.ts).
+      if (sellRunMinutes === 0) restartPenaltySek += k.sell_restart_penalty_sek;
+      // Export is limited by what battery + PV can physically supply beyond the house
+      // House has first dibs on the inverter's AC output; export gets the rest of the 15 kW rating
+      exportW = Math.min(sellSetW, k.inverter_max_ac_output_watts - s.houseW);
+      exportW = Math.max(exportW, 0);
+      // Average ramp factor over this slot: linear 0→100% across the first sell_ramp_minutes of the run
+      const rampMin = k.sell_ramp_minutes;
+      if (rampMin > 0 && sellRunMinutes < rampMin) {
+        const slotMin = s.durationH * 60;
+        const e0 = sellRunMinutes;
+        const e1 = e0 + slotMin;
+        const rampedUntil = Math.min(e1, rampMin);
+        const avgFactor =
+          ((rampedUntil * rampedUntil - e0 * e0) / (2 * rampMin) + Math.max(0, e1 - rampedUntil)) / slotMin;
+        exportW *= avgFactor;
+      }
+      sellRunMinutes += s.durationH * 60;
+    } else {
+      sellRunMinutes = 0;
+      if (buySetW === 0 && s.pvW < s.houseW + parasiticW + 380) {
+        // Baseline "feed when no solar" that nets out the inverter's constant grid draw
+        exportW = k.baseline_feed_watts;
+      }
+    }
+
+    let netBattW: number;
+    if (gridChargeW > 0) {
+      netBattW = s.pvW + gridChargeW;
+    } else {
+      netBattW = s.pvW - s.houseW - parasiticW - exportW;
+    }
+    const deltaWh =
+      netBattW >= 0 ? netBattW * k.charge_efficiency * s.durationH : (netBattW / k.discharge_efficiency) * s.durationH;
+    socWh += deltaWh;
+
+    if (socWh > cap) {
+      // Battery full: surplus PV flows to the grid by itself (solar-mode feeding)
+      const overflowInBatteryWh = socWh - cap;
+      autoExportWh += overflowInBatteryWh / k.charge_efficiency;
+      revenueSek += (overflowInBatteryWh / k.charge_efficiency / 1000) * (spot + k.sell_bonus_sek_per_kwh);
+      socWh = cap;
+    }
+    if (socWh < floorEmergencyWh) {
+      // Battery can't go lower — the house pulls the deficit from the grid (unavoidable import)
+      const deficitWh = floorEmergencyWh - socWh;
+      const importedForHouseWh = deficitWh * k.discharge_efficiency;
+      slotImportWh += importedForHouseWh;
+      socWh = floorEmergencyWh;
+    }
+
+    const exportedWh = exportW * s.durationH;
+    sellExportWh += sellSetW > 0 ? exportedWh : 0;
+    revenueSek += (exportedWh / 1000) * (spot + k.sell_bonus_sek_per_kwh);
+    importWh += slotImportWh;
+    revenueSek -= (slotImportWh / 1000) * (spot + k.buy_surcharges_sek_per_kwh) * k.vat_multiplier;
+
+    const floorWh = s.pvW > s.houseW + parasiticW ? floorSunnyWh : floorPlannerWh;
+    if (socWh < floorWh) violationWh += floorWh - socWh;
+    if (socWh < minSocWh) {
+      minSocWh = socWh;
+      minSocMs = s.endMs;
+    }
+    socAfterSlot[i] = socWh;
+  }
+
+  return {
+    revenueSek,
+    restartPenaltySek,
+    violationWh,
+    minSocWh,
+    minSocMs,
+    endSocWh: socWh,
+    sellExportWh,
+    autoExportWh,
+    importWh,
+    boughtWh,
+    socAfterSlot,
+  };
+}
+
+/**
+ * What the optimizer maximizes: cash revenue minus the (fictional) restart penalty. Every accept
+ * decision compares this; every user-facing projection reports plain revenueSek instead.
+ */
+export function objectiveSek(result: SimResult): number {
+  return result.revenueSek - result.restartPenaltySek;
+}
+
+export function overlapsVeto(
+  slot: { startMs: number; endMs: number },
+  vetoes: { startMs: number; endMs: number }[]
+): boolean {
+  return vetoes.some(veto => veto.startMs < slot.endMs && veto.endMs > slot.startMs);
+}
+
+/**
+ * Whether the planner may put NEW selling into this slot at all: priced, not claimed by a fixed
+ * (user/kept) window and not vetoed. Callers layer their own extra rules on top (the greedy adds
+ * the min-spot cutoff; fills/relocations add sellW/buyW-empty checks).
+ */
+export function slotTradableForSell(slot: Slot, sellVetoWindows: { startMs: number; endMs: number }[]): boolean {
+  return (
+    slot.spot !== undefined && slot.fixedSellW === 0 && slot.fixedBuyW === 0 && !overlapsVeto(slot, sellVetoWindows)
+  );
+}

--- a/backend/src/autoTrading/simulate.ts
+++ b/backend/src/autoTrading/simulate.ts
@@ -14,17 +14,17 @@ export function simulate(
   buyW: number[],
   tailSpot: number
 ): SimResult {
-  const k = input.knobs;
+  const knobs = input.knobs;
   const cap = input.capacityWh;
-  const floorPlannerWh = (k.planner_soc_floor_percent / 100) * cap + k.extra_reserve_kwh * 1000;
+  const floorPlannerWh = (knobs.planner_soc_floor_percent / 100) * cap + knobs.extra_reserve_kwh * 1000;
   // While forecast PV covers the house, a forecast miss costs minutes of import instead of a
   // stranded night — the reserve requirement drops accordingly (never above the normal floor).
   const floorSunnyWh = Math.min(
-    (k.planner_soc_floor_sunny_percent / 100) * cap + k.extra_reserve_kwh * 1000,
+    (knobs.planner_soc_floor_sunny_percent / 100) * cap + knobs.extra_reserve_kwh * 1000,
     floorPlannerWh
   );
-  const floorRuntimeWh = (k.runtime_soc_floor_percent / 100) * cap;
-  const floorEmergencyWh = (k.emergency_soc_floor_percent / 100) * cap;
+  const floorRuntimeWh = (knobs.runtime_soc_floor_percent / 100) * cap;
+  const floorEmergencyWh = (knobs.emergency_soc_floor_percent / 100) * cap;
 
   let socWh = (input.socPercent / 100) * cap;
   let revenueSek = 0;
@@ -41,11 +41,11 @@ export function simulate(
   let sellRunMinutes = 0;
 
   for (let i = 0; i < slots.length; i++) {
-    const s = slots[i];
-    const spot = s.spot ?? tailSpot;
+    const slot = slots[i];
+    const spot = slot.spot ?? tailSpot;
     const parasiticW = input.parasiticWatts;
-    const sellSetW = Math.max(sellW[i], s.fixedSellW);
-    const requestedBuyW = Math.max(buyW[i], s.fixedBuyW);
+    const sellSetW = Math.max(sellW[i], slot.fixedSellW);
+    const requestedBuyW = Math.max(buyW[i], slot.fixedBuyW);
     // Runtime never does both at once (feedWhenNoSolar errors out) — selling wins in our model
     const buySetW = sellSetW > 0 ? 0 : requestedBuyW;
 
@@ -57,72 +57,76 @@ export function simulate(
       // AC charging: battery charges from grid, house is fed from grid too
       gridChargeW = buySetW;
       slotImportWh +=
-        (buySetW + s.houseW + parasiticW - Math.min(s.pvW, buySetW + s.houseW + parasiticW)) * s.durationH;
-      boughtWh += buySetW * s.durationH;
+        (buySetW + slot.houseW + parasiticW - Math.min(slot.pvW, buySetW + slot.houseW + parasiticW)) * slot.durationH;
+      boughtWh += buySetW * slot.durationH;
     }
 
     const sellingThisSlot = sellSetW > 0 && socWh > floorRuntimeWh;
     if (sellingThisSlot) {
       // Export is limited by what battery + PV can physically supply beyond the house
       // House has first dibs on the inverter's AC output; export gets the rest of the 15 kW rating
-      exportW = Math.min(sellSetW, k.inverter_max_ac_output_watts - s.houseW);
+      exportW = Math.min(sellSetW, knobs.inverter_max_ac_output_watts - slot.houseW);
       exportW = Math.max(exportW, 0);
       // Average ramp factor over this slot: linear 0→100% across the first sell_ramp_minutes of the run
-      const rampMin = k.sell_ramp_minutes;
+      const rampMin = knobs.sell_ramp_minutes;
       if (rampMin > 0 && sellRunMinutes < rampMin) {
-        const slotMin = s.durationH * 60;
-        const e0 = sellRunMinutes;
-        const e1 = e0 + slotMin;
-        const rampedUntil = Math.min(e1, rampMin);
+        const slotMin = slot.durationH * 60;
+        const rampedFrom = sellRunMinutes;
+        const rampedTo = rampedFrom + slotMin;
+        const rampedUntil = Math.min(rampedTo, rampMin);
         const avgFactor =
-          ((rampedUntil * rampedUntil - e0 * e0) / (2 * rampMin) + Math.max(0, e1 - rampedUntil)) / slotMin;
+          ((rampedUntil * rampedUntil - rampedFrom * rampedFrom) / (2 * rampMin) +
+            Math.max(0, rampedTo - rampedUntil)) /
+          slotMin;
         exportW *= avgFactor;
       }
-      sellRunMinutes += s.durationH * 60;
+      sellRunMinutes += slot.durationH * 60;
     } else {
       sellRunMinutes = 0;
-      if (buySetW === 0 && s.pvW < s.houseW + parasiticW + 380) {
+      if (buySetW === 0 && slot.pvW < slot.houseW + parasiticW + 380) {
         // Baseline "feed when no solar" that nets out the inverter's constant grid draw
-        exportW = k.baseline_feed_watts;
+        exportW = knobs.baseline_feed_watts;
       }
     }
 
     let netBattW: number;
     if (gridChargeW > 0) {
-      netBattW = s.pvW + gridChargeW;
+      netBattW = slot.pvW + gridChargeW;
     } else {
-      netBattW = s.pvW - s.houseW - parasiticW - exportW;
+      netBattW = slot.pvW - slot.houseW - parasiticW - exportW;
     }
     const deltaWh =
-      netBattW >= 0 ? netBattW * k.charge_efficiency * s.durationH : (netBattW / k.discharge_efficiency) * s.durationH;
+      netBattW >= 0
+        ? netBattW * knobs.charge_efficiency * slot.durationH
+        : (netBattW / knobs.discharge_efficiency) * slot.durationH;
     socWh += deltaWh;
 
     if (socWh > cap) {
       // Battery full: surplus PV flows to the grid by itself (solar-mode feeding)
       const overflowInBatteryWh = socWh - cap;
-      autoExportWh += overflowInBatteryWh / k.charge_efficiency;
-      revenueSek += (overflowInBatteryWh / k.charge_efficiency / 1000) * (spot + k.sell_bonus_sek_per_kwh);
+      autoExportWh += overflowInBatteryWh / knobs.charge_efficiency;
+      revenueSek += (overflowInBatteryWh / knobs.charge_efficiency / 1000) * (spot + knobs.sell_bonus_sek_per_kwh);
       socWh = cap;
     }
     if (socWh < floorEmergencyWh) {
       // Battery can't go lower — the house pulls the deficit from the grid (unavoidable import)
       const deficitWh = floorEmergencyWh - socWh;
-      const importedForHouseWh = deficitWh * k.discharge_efficiency;
+      const importedForHouseWh = deficitWh * knobs.discharge_efficiency;
       slotImportWh += importedForHouseWh;
       socWh = floorEmergencyWh;
     }
 
-    const exportedWh = exportW * s.durationH;
+    const exportedWh = exportW * slot.durationH;
     sellExportWh += sellSetW > 0 ? exportedWh : 0;
-    revenueSek += (exportedWh / 1000) * (spot + k.sell_bonus_sek_per_kwh);
+    revenueSek += (exportedWh / 1000) * (spot + knobs.sell_bonus_sek_per_kwh);
     importWh += slotImportWh;
-    revenueSek -= (slotImportWh / 1000) * (spot + k.buy_surcharges_sek_per_kwh) * k.vat_multiplier;
+    revenueSek -= (slotImportWh / 1000) * (spot + knobs.buy_surcharges_sek_per_kwh) * knobs.vat_multiplier;
 
-    const floorWh = s.pvW > s.houseW + parasiticW ? floorSunnyWh : floorPlannerWh;
+    const floorWh = slot.pvW > slot.houseW + parasiticW ? floorSunnyWh : floorPlannerWh;
     if (socWh < floorWh) violationWh += floorWh - socWh;
     if (socWh < minSocWh) {
       minSocWh = socWh;
-      minSocMs = s.endMs;
+      minSocMs = slot.endMs;
     }
     socAfterSlot[i] = socWh;
   }

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -9,7 +9,7 @@ import type { Config } from "./config.types.ts";
 // sell setpoint, buy charging power and the planner's AC envelope all default to this nameplate.
 const INVERTER_NAMEPLATE_AC_WATTS = 15000;
 
-const default_config: Config = {
+export const default_config: Config = {
   automatic_trading: {
     enabled: false,
     price_area: "SE3",
@@ -21,6 +21,7 @@ const default_config: Config = {
     inverter_max_ac_output_watts: INVERTER_NAMEPLATE_AC_WATTS,
     max_buy_power_watts: INVERTER_NAMEPLATE_AC_WATTS,
     planner_soc_floor_percent: 10,
+    planner_soc_floor_sunny_percent: 5,
     emergency_soc_floor_percent: 3,
     extra_reserve_kwh: 0,
     min_sell_spot_sek_per_kwh: 0.08,
@@ -28,6 +29,7 @@ const default_config: Config = {
     min_buy_saving_sek_per_kwh: 0.25,
     allow_arbitrage_buying: true,
     sell_ramp_minutes: 10,
+    sell_restart_penalty_sek: 1,
     min_window_minutes: 15,
     charge_efficiency: 0.95,
     discharge_efficiency: 0.93,
@@ -125,6 +127,19 @@ const default_config: Config = {
   },
 };
 
+/**
+ * Top-level keys merge shallowly, but automatic_trading merges one level deeper: planner knobs get
+ * added over time, and a config.json written before a knob existed must still pick up its default
+ * (the planner does raw arithmetic on these — a missing knob would silently NaN every projection).
+ */
+function mergeWithDefaults(partial: Partial<Config>): Config {
+  return {
+    ...default_config,
+    ...partial,
+    automatic_trading: { ...default_config.automatic_trading, ...partial.automatic_trading },
+  };
+}
+
 export async function get_config_object(owner: Owner) {
   logLog("Getting config object");
   let config_writing_debounce: ReturnType<typeof setTimeout> | undefined;
@@ -144,7 +159,7 @@ export async function get_config_object(owner: Owner) {
       existing_config = {};
     }
   }
-  const initial_config = { ...default_config, ...existing_config } as const;
+  const initial_config = mergeWithDefaults(existing_config);
   const config_signal = createSignal<Config>(initial_config);
   const [get_config, set_actual_config] = config_signal;
 
@@ -177,7 +192,7 @@ export async function get_config_object(owner: Owner) {
       const set = (new_value: Config) => {
         // So that users can't accidentally delete keys
         // Use batch so that if two values update we don't run effects for both updates
-        batch(() => set_actual_config({ ...default_config, ...new_value }));
+        batch(() => set_actual_config(mergeWithDefaults(new_value)));
       };
       if (typeof new_value_or_setter === "function") {
         set(new_value_or_setter(untrack(get_config)));

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -29,7 +29,6 @@ export const default_config: Config = {
     min_buy_saving_sek_per_kwh: 0.25,
     allow_arbitrage_buying: true,
     sell_ramp_minutes: 10,
-    sell_restart_penalty_sek: 1,
     min_window_minutes: 15,
     charge_efficiency: 0.95,
     discharge_efficiency: 0.93,
@@ -39,7 +38,9 @@ export const default_config: Config = {
     // spotpris påslag 0.02 + nätnytta 0.072
     sell_bonus_sek_per_kwh: 0.092,
     constraint_tail_hours: 18,
-    guard_interval_minutes: 30,
+    // One tick per price slot; a healthy tick is cheap (forecasts/prices are cached, only the
+    // breach projection runs) and a breach gets caught one slot sooner
+    guard_interval_minutes: 15,
     opportunistic_replan_interval_minutes: 60,
     opportunistic_replan_min_gain_sek: 5,
     replan_retry_minutes: 15,

--- a/backend/src/config/config.types.ts
+++ b/backend/src/config/config.types.ts
@@ -15,6 +15,12 @@ export type AutomaticTradingConfig = {
   max_buy_power_watts: number;
   /** Planner keeps projected SOC above this (plus extra_reserve_kwh) at all times */
   planner_soc_floor_percent: number;
+  /**
+   * Reserve floor used instead of planner_soc_floor_percent while forecast PV covers the house —
+   * with solar flowing, a forecast miss costs minutes of grid import, not a stranded night.
+   * Keep ≤ planner_soc_floor_percent and ≥ the runtime cutoff (scheduled_power_selling.only_sell_above_soc).
+   */
+  planner_soc_floor_sunny_percent: number;
   /** Below this SOC the house effectively starts importing — used to price unavoidable imports */
   emergency_soc_floor_percent: number;
   /** Extra energy to keep in the battery on top of the floor, e.g. for charging the car. User knob. */
@@ -29,6 +35,13 @@ export type AutomaticTradingConfig = {
   allow_arbitrage_buying: boolean;
   /** The inverter ramps grid feed-in from 0 to full power over ~this many minutes (grid safety) */
   sell_ramp_minutes: number;
+  /**
+   * Charged once per sell-run start in the planning simulation. The spot curve alone often makes a
+   * fragmented schedule look marginally better (öre-level), but every stop/start costs real things
+   * the price math can't see: relay/mode churn on a quirky inverter and the ramp restart. This makes
+   * windows merge unless staying apart genuinely earns more than this.
+   */
+  sell_restart_penalty_sek: number;
   /** Generated windows shorter than this are dropped (inverter command churn isn't free) */
   min_window_minutes: number;
   charge_efficiency: number;

--- a/backend/src/config/config.types.ts
+++ b/backend/src/config/config.types.ts
@@ -35,13 +35,6 @@ export type AutomaticTradingConfig = {
   allow_arbitrage_buying: boolean;
   /** The inverter ramps grid feed-in from 0 to full power over ~this many minutes (grid safety) */
   sell_ramp_minutes: number;
-  /**
-   * Charged once per sell-run start in the planning simulation. The spot curve alone often makes a
-   * fragmented schedule look marginally better (öre-level), but every stop/start costs real things
-   * the price math can't see: relay/mode churn on a quirky inverter and the ramp restart. This makes
-   * windows merge unless staying apart genuinely earns more than this.
-   */
-  sell_restart_penalty_sek: number;
   /** Generated windows shorter than this are dropped (inverter command churn isn't free) */
   min_window_minutes: number;
   charge_efficiency: number;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -216,6 +216,11 @@ function main() {
                             if (!trader) return "auto trader not running";
                             return await trader.triggerPlanNow();
                           },
+                          clear_trading_vetoes: async () => {
+                            const trader = autoTrader();
+                            if (!trader) return "auto trader not running";
+                            return await trader.clearTradingVetoes();
+                          },
                         },
                         exposedAccessors: {
                           autoTraderStatus: () => autoTrader()?.autoTraderStatus(),

--- a/frontend/src/components/AutoTraderPanel.tsx
+++ b/frontend/src/components/AutoTraderPanel.tsx
@@ -28,29 +28,19 @@ export function AutoTraderPanel() {
     await setConfig({ ...current, automatic_trading: { ...current.automatic_trading, ...patch } });
   };
 
-  const generateNow = async () => {
+  const runAction = async (action: string, formatResult: (result: string) => string) => {
     setBusy(true);
     try {
-      const result = await sendBackendAction(socket, "generate_trading_plan");
-      await showToastWithMessage(owner, () => `Plan: ${result}`);
+      const result = await sendBackendAction(socket, action);
+      await showToastWithMessage(owner, () => formatResult(result ?? "ok"));
     } catch (e) {
       await showToastWithMessage(owner, () => `Failed: ${e}`);
     } finally {
       setBusy(false);
     }
   };
-
-  const clearVetoes = async () => {
-    setBusy(true);
-    try {
-      const result = await sendBackendAction(socket, "clear_trading_vetoes");
-      await showToastWithMessage(owner, () => `${result}`);
-    } catch (e) {
-      await showToastWithMessage(owner, () => `Failed: ${e}`);
-    } finally {
-      setBusy(false);
-    }
-  };
+  const generateNow = () => runAction("generate_trading_plan", result => `Plan: ${result}`);
+  const clearVetoes = () => runAction("clear_trading_vetoes", result => result);
 
   return (
     <section class="buy-sell-config__section">

--- a/frontend/src/components/AutoTraderPanel.tsx
+++ b/frontend/src/components/AutoTraderPanel.tsx
@@ -40,6 +40,18 @@ export function AutoTraderPanel() {
     }
   };
 
+  const clearVetoes = async () => {
+    setBusy(true);
+    try {
+      const result = await sendBackendAction(socket, "clear_trading_vetoes");
+      await showToastWithMessage(owner, () => `${result}`);
+    } catch (e) {
+      await showToastWithMessage(owner, () => `Failed: ${e}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
   return (
     <section class="buy-sell-config__section">
       <h2 class="buy-sell-config__subheading">Automatic trading</h2>
@@ -118,7 +130,15 @@ export function AutoTraderPanel() {
             Blocked ranges (you deleted planner windows there):{" "}
             {status()!
               .vetoes!.map(v => `${v.kind} ${fmtTime(v.start)}–${fmtTime(v.end)}`)
-              .join(", ")}
+              .join(", ")}{" "}
+            <button
+              type="button"
+              class="buy-sell-config__btn buy-sell-config__btn--secondary"
+              disabled={busy()}
+              onClick={() => void clearVetoes()}
+            >
+              {busy() ? "Working…" : "Unblock & replan"}
+            </button>
           </p>
         </Show>
         <Show when={status()!.guard}>


### PR DESCRIPTION
Fixes the auto-trader issues from the 2026-07-06/07 incidents, plus the veto-clear UI request.

## The "15 min Loch" comb (dad's screenshot)

Root cause: under a binding reserve budget the greedy takes the top-priced 15-min slots, which zigzagging day-ahead quarters scatter — and the ramp model amplifies it: near budget exhaustion a full-power contiguous slot no longer fits while an isolated, ramp-crippled (~⅔ energy) slot still does, so 15-minute holes win *systematically*.

Per owner decision, a comb that genuinely prices better is **kept** — a stop/start costs nothing on this inverter beyond the already-modeled ramp. What changes is that the planner stops leaving money on the table:

- **Consolidation pass** (`sellConsolidation.ts`): local-search moves — fill one-slot holes (alone or funded by dropping a cheap edge) when the recovered ramp beats the price dip, merge neighbouring runs by relocation when that's strictly better, extend run edges at **reduced power** so fractional leftover budget gets sold instead of stranded — every move re-simulated, feasibility-checked, applied only when simulated revenue improves. A final öre-capped pass equalizes power across each chain's post-ramp body so a chain lands as 1–2 schedule entries instead of a power staircase.
- **`planner_soc_floor_sunny_percent`** (default 5): the reserve floor relaxes in slots where forecast PV covers the house — a 9 AM forecast miss costs minutes of import, not a stranded night. (To actually sell below `only_sell_above_soc`, lower that runtime knob too.)

Validated against live prices/forecasts/SOC via read-only `planPreview`: tomorrow's evening plan comes out fully contiguous (`19:30–22:15`, one power step mid-chain) on ramp economics alone, min SOC ≥ floor, planner runtime ~50 ms.

## Guard re-plans instead of trimming (issue 1 from the incident report)

The July-6 log shows the trim loop removing the morning windows at 18:12/19:20, then trimming the 11 kWh evening window at 20:20 to fix a ~2 kWh deficit (min SOC jumped 8.4 % → 26.2 %) — and nothing ever re-added the now-feasible morning windows until a manual regenerate at 20:43.

Now: on a projected breach the guard runs a **full re-plan of the remaining horizon** (same path as the opportunistic replan, ungated, cached-prices-tolerant). It sheds exactly as much as needed, re-adds what became feasible, keeps active windows running (stubbing them to end now only when they *alone* breach), never touches user windows or vetoes. Owned buy windows are included in the breach projection (they recharge the battery — projecting without them fabricated breaches). If the re-plan itself fails, the guard sheds planner *sell* windows only, keeping buys. Identical regenerations are config no-ops (sorted-key comparison), and entries that ended >24 h ago are pruned on every plan apply. Default `guard_interval_minutes` is now 15 — one tick per price slot; healthy ticks are cheap since all inputs are cached.

## Veto-clear button

New ws action `clear_trading_vetoes` + an "Unblock & replan" button next to the blocked-ranges line: empties the vetoes under the schedule lock and immediately re-plans so the freed ranges get scheduled again.

## Also

- `automatic_trading` config now deep-merges its defaults, so configs written before a knob existed pick up the default instead of NaN-ing the planner (planPreview backfills the same way).
- `planner.ts` split per CLAUDE.md: simulation core → `simulate.ts`, consolidation → `sellConsolidation.ts`.
- Skipped by request: manual-plan retry (issue 2) — the user can just re-click.
- Added then removed by owner decision: a per-restart penalty knob (stop/starts are free; öre-better combs are kept).

## Testing

- `planner.selftest.ts`: 4 new scenarios (tight-budget zigzag evening → fractional budget captured at reduced power, floor safe; sunny floor sells more in the morning while nights stay protected; July-6 reconcile shape re-fills feasible windows; all 9 legacy scenarios unchanged).
- `yarn typecheck` clean; frontend tsc unchanged vs main (15 pre-existing errors, none in touched files).
- Read-only `planPreview.ts` dry-runs against the live pi config (schedules stripped copy) — no hardware touched; no second backend instance was ever started.

Deploy after merge: pull on the pi + `sudo systemctl restart mpi-15k-controller`, outside sell windows and clear of 13:10±10 Stockholm. Note the first startup rewrites config.json once (new knobs materialize via the deep merge). To get the 15-min guard cadence on the live system, change `guard_interval_minutes` via the config UI (the live config's explicit 30 wins over the new default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gnx4sUB71SzTnG5iP5dcZN
