### PR TITLE
Ah-based SOC ledger (shadow) + anchor rework

### DIFF
--- a/backend/src/autoTrading/autoTrader.ts
+++ b/backend/src/autoTrading/autoTrader.ts
@@ -30,7 +30,8 @@ import type { FixedWindow, PlannedWindow, PlannerInput } from "./planner.types.t
 type TraderCtx = {
   config: Accessor<Config>;
   setConfig: Awaited<ReturnType<typeof get_config_object>>[1];
-  averageSOC: Accessor<number | undefined>;
+  /** SOC clamped to [0,100] — the planner must never project from a nonsensical <0 / >100 start. */
+  clampedAverageSOC: Accessor<number | undefined>;
   assumedParasiticConsumption: Accessor<number>;
   influxClient: ReturnType<typeof useInfluxClient>;
   enabled: Accessor<boolean>;
@@ -50,7 +51,7 @@ type TraderCtx = {
 
 export function useAutoTrader({ configSignal }: { configSignal: Awaited<ReturnType<typeof get_config_object>> }) {
   const [config, setConfig] = configSignal;
-  const { averageSOC, assumedParasiticConsumption } = useBatteryValuesProvider();
+  const { clampedAverageSOC, assumedParasiticConsumption } = useBatteryValuesProvider();
   const [status, setStatus] = createSignal<AutoTraderStatus>({ enabled: false, note: "starting" });
   const [nextDailyRunAt, setNextDailyRunAt] = createSignal<string | undefined>();
   const enabled = createMemo(() => !!config().automatic_trading?.enabled);
@@ -58,7 +59,7 @@ export function useAutoTrader({ configSignal }: { configSignal: Awaited<ReturnTy
   const ctx: TraderCtx = {
     config,
     setConfig,
-    averageSOC,
+    clampedAverageSOC,
     assumedParasiticConsumption,
     influxClient: useInfluxClient(),
     enabled,
@@ -467,10 +468,10 @@ async function runPlan(ctx: TraderCtx, options: RunPlanOptions): Promise<string>
     }
     if (ctx.flags.aborted) return "aborted";
 
-    let soc = untrack(ctx.averageSOC);
+    let soc = untrack(ctx.clampedAverageSOC);
     for (let i = 0; i < 30 && soc === undefined && !ctx.flags.aborted; i++) {
       await wait(10_000);
-      soc = untrack(ctx.averageSOC);
+      soc = untrack(ctx.clampedAverageSOC);
     }
     if (soc === undefined) throw new Error("SOC not available — cannot plan");
     if (ctx.flags.aborted) return "aborted";
@@ -576,7 +577,7 @@ async function runGuard(ctx: TraderCtx) {
   const startedAt = Date.now();
   debugLog("Auto trader guard: tick");
   try {
-    const soc = untrack(ctx.averageSOC);
+    const soc = untrack(ctx.clampedAverageSOC);
     if (soc === undefined) return;
     const priceArea = untrack(ctx.config).automatic_trading.price_area;
     // For a breach decision slightly stale prices beat no guard run at all

--- a/backend/src/battery/ahLedger.ts
+++ b/backend/src/battery/ahLedger.ts
@@ -4,12 +4,11 @@ import type { Config } from "../config/config.types.ts";
 import type { InfluxClientAccessor } from "./useDatabasePower.ts";
 import { queryChargeIntegral } from "./queryChargeIntegral.ts";
 import { applyParameterTracking } from "./ahLedgerParameterTracking.ts";
-import { computeSocAh, type AnchorType } from "./ahLedgerMath.ts";
+import { computeSocAh, type LedgerAnchor } from "./ahLedgerMath.ts";
 import { useFromMqttProvider } from "../mqttValues/MQTTValuesProvider.ts";
 import { useNow } from "../utilities/useNow.ts";
 import { logLog, warnLog } from "../utilities/logging.ts";
 
-type LedgerAnchor = { at: number; soc: number; type: AnchorType };
 type ActiveAnchor = LedgerAnchor & { drainA: number; capacityAh: number };
 
 /**

--- a/backend/src/battery/ahLedger.ts
+++ b/backend/src/battery/ahLedger.ts
@@ -98,6 +98,10 @@ export function ahLedger({
   }, undefined);
 
   const socAh = createMemo(() => {
+    // While a re-anchor's DB refetch is in flight, totalAh() still holds the OLD span's integral (the
+    // re-anchor effect needs that stale read for parameter tracking) — but against the NEW anchor it
+    // would compute a wild one-off spike, so hold the output until the fresh integral lands.
+    if (databaseAh.loading) return undefined;
     const anchor = activeAnchor();
     const integralAh = totalAh();
     if (!anchor || integralAh == undefined) return undefined;

--- a/backend/src/battery/ahLedger.ts
+++ b/backend/src/battery/ahLedger.ts
@@ -1,0 +1,134 @@
+import { type Accessor, createEffect, createMemo, createResource, createSignal, untrack } from "solid-js";
+import type { get_config_object } from "../config/config.ts";
+import type { Config } from "../config/config.types.ts";
+import type { InfluxClientAccessor } from "./useDatabasePower.ts";
+import { queryChargeIntegral } from "./queryChargeIntegral.ts";
+import { applyParameterTracking } from "./ahLedgerParameterTracking.ts";
+import { computeSocAh, type AnchorType } from "./ahLedgerMath.ts";
+import { useFromMqttProvider } from "../mqttValues/MQTTValuesProvider.ts";
+import { useNow } from "../utilities/useNow.ts";
+import { warnLog } from "../utilities/logging.ts";
+
+type LedgerAnchor = { at: number; soc: number; type: AnchorType };
+type ActiveAnchor = LedgerAnchor & { drainA: number; capacityAh: number };
+
+/**
+ * The Ah (coulomb-counting) SOC ledger — Phase 1's shadow of the Wh system. Anchored at the latest
+ * full/empty/soft-empty event (`latestAnchor`), it restores ∫amps from that anchor out of InfluxDB once
+ * (via the raw-mV subquery, so it survives deploys) and then accumulates live from the hall amps signal,
+ * mirroring calculateBatteryEnergy. `soc_ah` is published UNclamped so the drift shows in Grafana.
+ *
+ * On each re-anchor it (a) hands the completed span to the online drain/capacity EMA tracker, then
+ * (b) snapshots the (possibly just-updated) drain/capacity into the new anchor. The SOC formula reads
+ * those snapshots, never live config, so a parameter update only ever changes the future — no retroactive
+ * step across the span that just ended.
+ */
+export function ahLedger({
+  configSignal: [config, setConfig],
+  influxClient,
+  batteryCurrentAmps,
+  latestAnchor,
+}: {
+  configSignal: Awaited<ReturnType<typeof get_config_object>>;
+  influxClient: InfluxClientAccessor;
+  batteryCurrentAmps: Accessor<{ value: number; time: number } | undefined>;
+  latestAnchor: Accessor<LedgerAnchor | undefined>;
+}) {
+  const [activeAnchor, setActiveAnchor] = createSignal<ActiveAnchor | undefined>(undefined);
+  const [accumulationToggle, setAccumulationToggle] = createSignal(false);
+  let localAh = 0;
+  let lastAmps: { value: number; time: number } | undefined;
+
+  // Charge integrated in the database from the anchor up to app start; re-queried whenever we re-anchor.
+  const [databaseAh] = createResource(
+    () => ({ anchorAt: latestAnchor()?.at, database: influxClient() }),
+    async ({ anchorAt, database }) => {
+      if (!anchorAt || !database) return undefined;
+      const currentMeasuring = untrack(() => config().current_measuring);
+      return await queryChargeIntegral(
+        database,
+        anchorAt,
+        currentMeasuring.zero_current_millivolts2,
+        currentMeasuring.millivolts_per_ampere2
+      );
+    }
+  );
+
+  // Accumulate live amp-hours (trapezoidal via the previous sample, like calculateBatteryEnergy's power).
+  createEffect(() => {
+    const amps = batteryCurrentAmps();
+    if (!amps) return;
+    if (lastAmps) {
+      const durationHours = (amps.time - lastAmps.time) / 1000 / 60 / 60;
+      localAh += lastAmps.value * durationHours;
+    }
+    lastAmps = amps;
+    setAccumulationToggle(previous => !previous);
+  });
+
+  const totalAh = createMemo(() => {
+    accumulationToggle();
+    const databaseValue = databaseAh();
+    if (databaseValue == undefined) return undefined;
+    return databaseValue + localAh;
+  });
+
+  // Re-anchor: depends only on the anchor time (primitive) so unrelated config writes can't retrigger it.
+  createEffect<number | undefined>(previousAnchorAt => {
+    const anchor = latestAnchor();
+    const anchorAt = anchor?.at;
+    if (!anchor || anchorAt === previousAnchorAt) return anchorAt;
+    untrack(() => {
+      const previous = activeAnchor();
+      const spanIntegralAh = totalAh(); // ∫amps since the previous anchor (DB resource still holds its old value)
+      if (previous && spanIntegralAh != undefined) {
+        applyParameterTracking({ previousAnchor: previous, nextAnchor: anchor, spanIntegralAh, config, setConfig });
+      }
+      localAh = 0; // keep lastAmps so the first post-anchor sample still bridges (mirrors the Wh ledger)
+      const ahLedgerConfig = config().soc_calculations.ah_ledger; // read AFTER the update above → forward-only
+      setActiveAnchor({
+        at: anchor.at,
+        soc: anchor.soc,
+        type: anchor.type,
+        drainA: ahLedgerConfig.drain_a,
+        capacityAh: ahLedgerConfig.capacity_ah,
+      });
+    });
+    return anchorAt;
+  }, undefined);
+
+  const socAh = createMemo(() => {
+    const anchor = activeAnchor();
+    const integralAh = totalAh();
+    if (!anchor || integralAh == undefined) return undefined;
+    return computeSocAh({
+      anchorSoc: anchor.soc,
+      integralAh,
+      drainA: anchor.drainA,
+      elapsedHours: (useNow() - anchor.at) / 1000 / 60 / 60,
+      capacityAh: anchor.capacityAh,
+    });
+  });
+
+  publishSocAh({ config, socAh });
+
+  return { socAh };
+}
+
+function publishSocAh({ config, socAh }: { config: Accessor<Config>; socAh: Accessor<number | undefined> }) {
+  const { mqttClient } = useFromMqttProvider();
+  createEffect(() => {
+    const client = mqttClient();
+    if (!client) return;
+    createEffect(() => {
+      const value = socAh();
+      // Publish UNclamped, but never NaN/±Infinity (that would corrupt the line-protocol point).
+      if (value == undefined || !isFinite(value)) return;
+      const table = untrack(() => config().soc_calculations.table);
+      const line = `${table} soc_ah=${value}`;
+      if (client.connected) {
+        client.publish(table, line).catch(error => warnLog("Failed to publish soc_ah", error));
+      }
+    });
+  });
+}

--- a/backend/src/battery/ahLedger.ts
+++ b/backend/src/battery/ahLedger.ts
@@ -7,7 +7,7 @@ import { applyParameterTracking } from "./ahLedgerParameterTracking.ts";
 import { computeSocAh, type AnchorType } from "./ahLedgerMath.ts";
 import { useFromMqttProvider } from "../mqttValues/MQTTValuesProvider.ts";
 import { useNow } from "../utilities/useNow.ts";
-import { warnLog } from "../utilities/logging.ts";
+import { logLog, warnLog } from "../utilities/logging.ts";
 
 type LedgerAnchor = { at: number; soc: number; type: AnchorType };
 type ActiveAnchor = LedgerAnchor & { drainA: number; capacityAh: number };
@@ -36,6 +36,8 @@ export function ahLedger({
 }) {
   const [activeAnchor, setActiveAnchor] = createSignal<ActiveAnchor | undefined>(undefined);
   const [accumulationToggle, setAccumulationToggle] = createSignal(false);
+  // Anchors older than this are restore-time reconstructions, not live events — see the tracking gate below.
+  const ledgerStartedAt = +new Date();
   let localAh = 0;
   let lastAmps: { value: number; time: number } | undefined;
 
@@ -82,7 +84,14 @@ export function ahLedger({
       const previous = activeAnchor();
       const spanIntegralAh = totalAh(); // ∫amps since the previous anchor (DB resource still holds its old value)
       if (previous && spanIntegralAh != undefined) {
-        applyParameterTracking({ previousAnchor: previous, nextAnchor: anchor, spanIntegralAh, config, setConfig });
+        if (anchor.at > ledgerStartedAt) {
+          applyParameterTracking({ previousAnchor: previous, nextAnchor: anchor, spanIntegralAh, config, setConfig });
+        } else {
+          // Restored (pre-start) anchor: totalAh() measures previous→NOW, not previous→anchor, so hours of
+          // post-anchor flow would corrupt the estimate (seen on first deploy: a 6 h-stale full→empty span
+          // implied 949 Ah). Live events fire within seconds of the condition, where now ≈ anchor time.
+          logLog("Ah ledger: skipping parameter tracking for restored span", previous.type, "→", anchor.type);
+        }
       }
       localAh = 0; // keep lastAmps so the first post-anchor sample still bridges (mirrors the Wh ledger)
       const ahLedgerConfig = config().soc_calculations.ah_ledger; // read AFTER the update above → forward-only

--- a/backend/src/battery/ahLedgerMath.selftest.ts
+++ b/backend/src/battery/ahLedgerMath.selftest.ts
@@ -1,0 +1,238 @@
+/**
+ * Pure self-test for the Ah ledger math (no hardware, no DB). Run from backend/ with:
+ *   yarn node src/battery/ahLedgerMath.selftest.ts
+ */
+import {
+  computeSocAh,
+  classifyAnchorTransition,
+  capacityWeightForTransition,
+  drainEmaWeight,
+  computeParameterUpdates,
+} from "./ahLedgerMath.ts";
+
+const fails: string[] = [];
+function check(name: string, cond: boolean, detail = "") {
+  console.log(`${cond ? "PASS" : "FAIL"}: ${name} ${detail}`);
+  if (!cond) fails.push(name);
+}
+function approx(actual: number, expected: number, epsilon = 0.001): boolean {
+  return Math.abs(actual - expected) < epsilon;
+}
+
+// ---------- computeSocAh ----------
+{
+  // 620 Ah discharged + 2.8 A drain over 10 h out of 1240 Ah, from a full anchor.
+  const soc = computeSocAh({ anchorSoc: 100, integralAh: -620, drainA: 2.8, elapsedHours: 10, capacityAh: 1240 });
+  check("computeSocAh: discharge from full", approx(soc, 47.742, 0.01), `(${soc.toFixed(3)})`);
+  // At the instant of anchoring (no integral, no elapsed) SOC equals the anchor SOC exactly.
+  check(
+    "computeSocAh: at anchor == anchor soc",
+    computeSocAh({ anchorSoc: 0.4, integralAh: 0, drainA: 2.8, elapsedHours: 0, capacityAh: 1240 }) === 0.4
+  );
+}
+
+// ---------- classifyAnchorTransition ----------
+{
+  check("classify full→full = drain", classifyAnchorTransition("full", "full") === "drain");
+  check("classify full→empty = capacity", classifyAnchorTransition("full", "empty") === "capacity");
+  check("classify full→soft_empty = capacity", classifyAnchorTransition("full", "soft_empty") === "capacity");
+  check("classify empty→full = capacity", classifyAnchorTransition("empty", "full") === "capacity");
+  check("classify soft_empty→full = capacity", classifyAnchorTransition("soft_empty", "full") === "capacity");
+  check("classify empty→soft_empty = none", classifyAnchorTransition("empty", "soft_empty") === "none");
+  check("classify soft_empty→empty = none", classifyAnchorTransition("soft_empty", "empty") === "none");
+  check("classify soft_empty→soft_empty = none", classifyAnchorTransition("soft_empty", "soft_empty") === "none");
+  check("classify empty→empty = none", classifyAnchorTransition("empty", "empty") === "none");
+}
+
+// ---------- capacityWeightForTransition ----------
+{
+  check(
+    "weight full↔empty = 0.25",
+    capacityWeightForTransition("full", "empty") === 0.25 && capacityWeightForTransition("empty", "full") === 0.25
+  );
+  check(
+    "weight full↔soft_empty = 0.10",
+    capacityWeightForTransition("full", "soft_empty") === 0.1 &&
+      capacityWeightForTransition("soft_empty", "full") === 0.1
+  );
+}
+
+// ---------- drainEmaWeight ----------
+{
+  check("drainEmaWeight(0) = 0", drainEmaWeight(0, 7) === 0);
+  check(
+    "drainEmaWeight(7,7) = 1-1/e",
+    approx(drainEmaWeight(7, 7), 1 - Math.exp(-1)),
+    `(${drainEmaWeight(7, 7).toFixed(4)})`
+  );
+  check(
+    "drainEmaWeight monotone in dt",
+    drainEmaWeight(1, 7) < drainEmaWeight(3, 7) && drainEmaWeight(3, 7) < drainEmaWeight(10, 7)
+  );
+  // Across the whole usable full→full span range (6 h … 14 d) the weight stays a proper fraction < 1.
+  check(
+    "drainEmaWeight < 1 over usable span",
+    drainEmaWeight(6 / 24, 7) > 0 && drainEmaWeight(14, 7) < 1,
+    `(${drainEmaWeight(14, 7).toFixed(4)})`
+  );
+}
+
+// ---------- computeParameterUpdates: drain ----------
+{
+  // full→full over 1 day, implied drain 2.8 A, EMA from 2.0 with tau 7.
+  const result = computeParameterUpdates({
+    prevType: "full",
+    nextType: "full",
+    prevSoc: 100,
+    nextSoc: 100,
+    dtHours: 24,
+    spanIntegralAh: 2.8 * 24,
+    currentDrainA: 2.0,
+    currentCapacityAh: 1240,
+    drainEmaTauDays: 7,
+  });
+  check("drain: accepted, no capacity", result.drainA !== undefined && result.capacityAh === undefined);
+  check(
+    "drain: EMA value",
+    result.drainA !== undefined && approx(result.drainA, 2.1065, 0.001),
+    `(${result.drainA?.toFixed(4)})`
+  );
+  check("drain: emits a log line", result.logs.length === 1 && result.logs[0].level === "log");
+}
+{
+  // Span too short (<6 h) → skipped silently.
+  const short = computeParameterUpdates({
+    prevType: "full",
+    nextType: "full",
+    prevSoc: 100,
+    nextSoc: 100,
+    dtHours: 3,
+    spanIntegralAh: 8,
+    currentDrainA: 2.0,
+    currentCapacityAh: 1240,
+    drainEmaTauDays: 7,
+  });
+  check("drain: <6 h skipped", short.drainA === undefined && short.logs.length === 0);
+  // Span too long (>14 d) → skipped silently.
+  const long = computeParameterUpdates({
+    prevType: "full",
+    nextType: "full",
+    prevSoc: 100,
+    nextSoc: 100,
+    dtHours: 15 * 24,
+    spanIntegralAh: 1000,
+    currentDrainA: 2.0,
+    currentCapacityAh: 1240,
+    drainEmaTauDays: 7,
+  });
+  check("drain: >14 d skipped", long.drainA === undefined && long.logs.length === 0);
+  // Implausible implied drain (>10 A) → rejected with an error log, no update.
+  const rejected = computeParameterUpdates({
+    prevType: "full",
+    nextType: "full",
+    prevSoc: 100,
+    nextSoc: 100,
+    dtHours: 6,
+    spanIntegralAh: 66,
+    currentDrainA: 2.0,
+    currentCapacityAh: 1240,
+    drainEmaTauDays: 7,
+  });
+  check(
+    "drain: |implied|>10 rejected",
+    rejected.drainA === undefined && rejected.logs.length === 1 && rejected.logs[0].level === "error"
+  );
+}
+
+// ---------- computeParameterUpdates: capacity ----------
+{
+  // full→empty, ΔSOC -100, implied capacity |−1140 − 2.5·40| = 1240, EMA from 1200 with weight 0.25.
+  const result = computeParameterUpdates({
+    prevType: "full",
+    nextType: "empty",
+    prevSoc: 100,
+    nextSoc: 0,
+    dtHours: 40,
+    spanIntegralAh: -1140,
+    currentDrainA: 2.5,
+    currentCapacityAh: 1200,
+    drainEmaTauDays: 7,
+  });
+  check("capacity: accepted, no drain", result.capacityAh !== undefined && result.drainA === undefined);
+  check(
+    "capacity: EMA value",
+    result.capacityAh !== undefined && approx(result.capacityAh, 1210, 0.001),
+    `(${result.capacityAh?.toFixed(2)})`
+  );
+  check(
+    "capacity: soft_empty weight 0.10",
+    (() => {
+      const r = computeParameterUpdates({
+        prevType: "full",
+        nextType: "soft_empty",
+        prevSoc: 100,
+        nextSoc: 0.4,
+        dtHours: 40,
+        spanIntegralAh: -1140,
+        currentDrainA: 2.5,
+        currentCapacityAh: 1200,
+        drainEmaTauDays: 7,
+      });
+      // implied ≈ |−1140 − 100| / (99.6/100) = 1240/0.996 = 1244.98; EMA 0.9·1200 + 0.1·1244.98 = 1204.5
+      return r.capacityAh !== undefined && approx(r.capacityAh, 1204.5, 0.1);
+    })()
+  );
+}
+{
+  // |ΔSOC| < 90 → not a deep enough span, skipped.
+  const shallow = computeParameterUpdates({
+    prevType: "full",
+    nextType: "empty",
+    prevSoc: 100,
+    nextSoc: 15,
+    dtHours: 40,
+    spanIntegralAh: -1000,
+    currentDrainA: 2.5,
+    currentCapacityAh: 1200,
+    drainEmaTauDays: 7,
+  });
+  check("capacity: |ΔSOC|<90 skipped", shallow.capacityAh === undefined && shallow.logs.length === 0);
+  // Implied capacity outside 1000–1500 → rejected with an error log.
+  const insane = computeParameterUpdates({
+    prevType: "full",
+    nextType: "empty",
+    prevSoc: 100,
+    nextSoc: 0,
+    dtHours: 40,
+    spanIntegralAh: -2000,
+    currentDrainA: 2.5,
+    currentCapacityAh: 1200,
+    drainEmaTauDays: 7,
+  });
+  check(
+    "capacity: out-of-range rejected",
+    insane.capacityAh === undefined && insane.logs.length === 1 && insane.logs[0].level === "error"
+  );
+}
+
+// ---------- computeParameterUpdates: none transitions do nothing ----------
+{
+  const none = computeParameterUpdates({
+    prevType: "empty",
+    nextType: "soft_empty",
+    prevSoc: 0,
+    nextSoc: 0.4,
+    dtHours: 5,
+    spanIntegralAh: 3,
+    currentDrainA: 2.5,
+    currentCapacityAh: 1200,
+    drainEmaTauDays: 7,
+  });
+  check(
+    "none: no updates, no logs",
+    none.drainA === undefined && none.capacityAh === undefined && none.logs.length === 0
+  );
+}
+
+console.log(fails.length ? `\n${fails.length} FAILURES: ${fails.join(", ")}` : "\nAll ledger-math checks passed");
+process.exit(fails.length ? 1 : 0);

--- a/backend/src/battery/ahLedgerMath.ts
+++ b/backend/src/battery/ahLedgerMath.ts
@@ -3,6 +3,12 @@
 
 export type AnchorType = "full" | "empty" | "soft_empty";
 
+/** An anchor event the Ah ledger can hang off: when it happened and the SOC it pins. */
+export type LedgerAnchor = { at: number; soc: number; type: AnchorType };
+
+/** Influx measurement + MQTT topic for anchor markers — shared so publish and restore can never drift. */
+export const SOC_ANCHORS_MEASUREMENT = "soc_anchors";
+
 /** A structured log request produced by the pure layer; the caller dispatches to errorLog/warnLog/logLog. */
 export type ParameterLog = { level: "log" | "warn" | "error"; message: string };
 

--- a/backend/src/battery/ahLedgerMath.ts
+++ b/backend/src/battery/ahLedgerMath.ts
@@ -1,0 +1,128 @@
+// Pure math for the Ah (coulomb-counting) SOC ledger and its online parameter tracking. No runtime
+// imports on purpose: everything here is exercised by ahLedgerMath.selftest.ts without hardware or DB.
+
+export type AnchorType = "full" | "empty" | "soft_empty";
+
+/** A structured log request produced by the pure layer; the caller dispatches to errorLog/warnLog/logLog. */
+export type ParameterLog = { level: "log" | "warn" | "error"; message: string };
+
+/**
+ * The ledger equation. `integralAh` is ∫amps·dt since the anchor (charge positive), `drainA` the
+ * constant hourly amp offset to remove, `elapsedHours` the wall-clock time since the anchor.
+ * Deliberately UNclamped — callers clamp only at consumption; the raw drift is wanted in Grafana.
+ */
+export function computeSocAh({
+  anchorSoc,
+  integralAh,
+  drainA,
+  elapsedHours,
+  capacityAh,
+}: {
+  anchorSoc: number;
+  integralAh: number;
+  drainA: number;
+  elapsedHours: number;
+  capacityAh: number;
+}): number {
+  return anchorSoc + ((integralAh - drainA * elapsedHours) / capacityAh) * 100;
+}
+
+/**
+ * Which online parameter a completed anchor-to-anchor span updates:
+ *  - full→full: the drain (SOC returns to 100, so the net charge is exactly the drain loss).
+ *  - full↔empty or full↔soft_empty: the usable capacity (a deep, known ΔSOC lever arm).
+ *  - anything else (empty↔soft_empty, empty↔empty, …): nothing usable.
+ */
+export function classifyAnchorTransition(prevType: AnchorType, nextType: AnchorType): "drain" | "capacity" | "none" {
+  if (prevType === "full" && nextType === "full") return "drain";
+  const fullToLow = prevType === "full" && (nextType === "empty" || nextType === "soft_empty");
+  const lowToFull = (prevType === "empty" || prevType === "soft_empty") && nextType === "full";
+  if (fullToLow || lowToFull) return "capacity";
+  return "none";
+}
+
+/** Hard empty is trusted more than the soft (partial-discharge) empty for capacity estimation. */
+export function capacityWeightForTransition(prevType: AnchorType, nextType: AnchorType): number {
+  const nonFullEnd = prevType === "full" ? nextType : prevType;
+  return nonFullEnd === "empty" ? 0.25 : 0.1;
+}
+
+/** EMA weight for a drain update: longer spans (relative to tau) carry more weight, in [0, 1). */
+export function drainEmaWeight(dtDays: number, tauDays: number): number {
+  return 1 - Math.exp(-dtDays / tauDays);
+}
+
+/**
+ * Decide what (if anything) a just-completed span teaches the ledger. Pure and total: returns the new
+ * parameter value(s) to persist plus any log lines (rejections and accepted updates). Gates:
+ *  - drain only from full→full spans with 6 h ≤ dt ≤ 14 d; reject |implied| > 10 A (errorLog).
+ *  - capacity only from full↔empty / full↔soft_empty spans with |ΔSOC| ≥ 90 pp; sanity 1000–1500 Ah.
+ */
+export function computeParameterUpdates({
+  prevType,
+  nextType,
+  prevSoc,
+  nextSoc,
+  dtHours,
+  spanIntegralAh,
+  currentDrainA,
+  currentCapacityAh,
+  drainEmaTauDays,
+}: {
+  prevType: AnchorType;
+  nextType: AnchorType;
+  prevSoc: number;
+  nextSoc: number;
+  dtHours: number;
+  spanIntegralAh: number;
+  currentDrainA: number;
+  currentCapacityAh: number;
+  drainEmaTauDays: number;
+}): { drainA?: number; capacityAh?: number; logs: ParameterLog[] } {
+  const logs: ParameterLog[] = [];
+  const dtDays = dtHours / 24;
+  const transition = classifyAnchorTransition(prevType, nextType);
+
+  if (dtHours <= 0) return { logs }; // degenerate / out-of-order span
+
+  if (transition === "drain") {
+    if (dtHours < 6 || dtDays > 14) return { logs }; // span not in the usable full→full window
+    const impliedDrainA = spanIntegralAh / dtHours;
+    if (Math.abs(impliedDrainA) > 10) {
+      logs.push({
+        level: "error",
+        message: `Ah ledger: rejecting full→full drain estimate ${impliedDrainA.toFixed(2)} A (>|10 A|); span ${dtDays.toFixed(2)} d, net ${spanIntegralAh.toFixed(1)} Ah`,
+      });
+      return { logs };
+    }
+    const weight = drainEmaWeight(dtDays, drainEmaTauDays);
+    const drainA = (1 - weight) * currentDrainA + weight * impliedDrainA;
+    logs.push({
+      level: "log",
+      message: `Ah ledger: drain ${currentDrainA.toFixed(3)}→${drainA.toFixed(3)} A (implied ${impliedDrainA.toFixed(3)}, w ${weight.toFixed(3)}, span ${dtDays.toFixed(2)} d)`,
+    });
+    return { drainA, logs };
+  }
+
+  if (transition === "capacity") {
+    const deltaSocPp = nextSoc - prevSoc;
+    if (Math.abs(deltaSocPp) < 90) return { logs }; // not a deep enough span to identify capacity
+    const impliedCapacityAh = Math.abs(spanIntegralAh - currentDrainA * dtHours) / (Math.abs(deltaSocPp) / 100);
+    if (impliedCapacityAh < 1000 || impliedCapacityAh > 1500) {
+      logs.push({
+        level: "error",
+        message: `Ah ledger: rejecting capacity estimate ${impliedCapacityAh.toFixed(0)} Ah (outside 1000–1500); span ${dtDays.toFixed(2)} d, ΔSOC ${deltaSocPp.toFixed(1)} pp`,
+      });
+      return { logs };
+    }
+    const weight = capacityWeightForTransition(prevType, nextType);
+    const capacityAh = (1 - weight) * currentCapacityAh + weight * impliedCapacityAh;
+    logs.push({
+      level: "log",
+      message: `Ah ledger: capacity ${currentCapacityAh.toFixed(0)}→${capacityAh.toFixed(0)} Ah (implied ${impliedCapacityAh.toFixed(0)}, w ${weight}, ΔSOC ${deltaSocPp.toFixed(1)} pp)`,
+    });
+    return { capacityAh, logs };
+  }
+
+  return { logs };
+}

--- a/backend/src/battery/ahLedgerParameterTracking.ts
+++ b/backend/src/battery/ahLedgerParameterTracking.ts
@@ -3,7 +3,6 @@ import type { get_config_object } from "../config/config.ts";
 import { computeParameterUpdates, type LedgerAnchor } from "./ahLedgerMath.ts";
 import { errorLog, logLog, warnLog } from "../utilities/logging.ts";
 
-
 /**
  * Feeds a just-completed anchor→anchor span to the pure EMA logic, emits its log lines, and persists any
  * accepted drain/capacity update into config (like the Wh fitter persists current_state). Updates apply

--- a/backend/src/battery/ahLedgerParameterTracking.ts
+++ b/backend/src/battery/ahLedgerParameterTracking.ts
@@ -1,9 +1,8 @@
 import { untrack } from "solid-js";
 import type { get_config_object } from "../config/config.ts";
-import { computeParameterUpdates, type AnchorType } from "./ahLedgerMath.ts";
+import { computeParameterUpdates, type LedgerAnchor } from "./ahLedgerMath.ts";
 import { errorLog, logLog, warnLog } from "../utilities/logging.ts";
 
-type LedgerAnchor = { at: number; soc: number; type: AnchorType };
 
 /**
  * Feeds a just-completed anchor→anchor span to the pure EMA logic, emits its log lines, and persists any

--- a/backend/src/battery/ahLedgerParameterTracking.ts
+++ b/backend/src/battery/ahLedgerParameterTracking.ts
@@ -1,0 +1,60 @@
+import { untrack } from "solid-js";
+import type { get_config_object } from "../config/config.ts";
+import { computeParameterUpdates, type AnchorType } from "./ahLedgerMath.ts";
+import { errorLog, logLog, warnLog } from "../utilities/logging.ts";
+
+type LedgerAnchor = { at: number; soc: number; type: AnchorType };
+
+/**
+ * Feeds a just-completed anchor→anchor span to the pure EMA logic, emits its log lines, and persists any
+ * accepted drain/capacity update into config (like the Wh fitter persists current_state). Updates apply
+ * FORWARD ONLY: this runs at a re-anchor, where the ledger is about to snapshot the fresh config values
+ * for the new span, so a changed parameter never retroactively re-scores the span that just ended.
+ */
+export function applyParameterTracking({
+  previousAnchor,
+  nextAnchor,
+  spanIntegralAh,
+  config,
+  setConfig,
+}: {
+  previousAnchor: LedgerAnchor;
+  nextAnchor: LedgerAnchor;
+  spanIntegralAh: number;
+  config: Awaited<ReturnType<typeof get_config_object>>[0];
+  setConfig: Awaited<ReturnType<typeof get_config_object>>[1];
+}) {
+  const ahLedgerConfig = untrack(() => config().soc_calculations.ah_ledger);
+
+  const { drainA, capacityAh, logs } = computeParameterUpdates({
+    prevType: previousAnchor.type,
+    nextType: nextAnchor.type,
+    prevSoc: previousAnchor.soc,
+    nextSoc: nextAnchor.soc,
+    dtHours: (nextAnchor.at - previousAnchor.at) / 1000 / 60 / 60,
+    spanIntegralAh,
+    currentDrainA: ahLedgerConfig.drain_a,
+    currentCapacityAh: ahLedgerConfig.capacity_ah,
+    drainEmaTauDays: ahLedgerConfig.drain_ema_tau_days,
+  });
+
+  for (const entry of logs) {
+    if (entry.level === "error") errorLog(entry.message);
+    else if (entry.level === "warn") warnLog(entry.message);
+    else logLog(entry.message);
+  }
+
+  if (drainA === undefined && capacityAh === undefined) return;
+
+  setConfig(previous => ({
+    ...previous,
+    soc_calculations: {
+      ...previous.soc_calculations,
+      ah_ledger: {
+        ...previous.soc_calculations.ah_ledger,
+        ...(drainA !== undefined ? { drain_a: drainA } : {}),
+        ...(capacityAh !== undefined ? { capacity_ah: capacityAh } : {}),
+      },
+    },
+  }));
+}

--- a/backend/src/battery/anchorConditions.ts
+++ b/backend/src/battery/anchorConditions.ts
@@ -1,0 +1,18 @@
+// Shared, pure anchor predicates so the Wh path (useLastFullAndEmpty) and the Ah path
+// (anchorDetection) can never drift on what "full"/"empty" means. Hall sensor 2 amps, positive =
+// charging; both take already-1-min-smoothed amps.
+
+/** Full: held at the full setpoint while the (smoothed) charge current has tapered below the stop threshold. */
+export function fullConditionMet(
+  voltageVolts: number,
+  smoothedAmps: number,
+  fullBatteryVoltage: number,
+  stopChargingBelowCurrent: number
+): boolean {
+  return voltageVolts >= fullBatteryVoltage && smoothedAmps < stopChargingBelowCurrent;
+}
+
+/** Empty: terminal voltage has sagged to (or below) the hard-empty voltage. */
+export function emptyConditionMet(voltageVolts: number, batteryEmptyAtVoltage: number): boolean {
+  return voltageVolts <= batteryEmptyAtVoltage;
+}

--- a/backend/src/battery/anchorDetection.ts
+++ b/backend/src/battery/anchorDetection.ts
@@ -4,7 +4,7 @@ import { useFromMqttProvider } from "../mqttValues/MQTTValuesProvider.ts";
 import { reactiveBatteryVoltage, reactiveBatteryVoltageTime } from "../mqttValues/mqttHelpers.ts";
 import { fullConditionMet, emptyConditionMet } from "./anchorConditions.ts";
 import { warnLog } from "../utilities/logging.ts";
-import type { AnchorType } from "./ahLedgerMath.ts";
+import { SOC_ANCHORS_MEASUREMENT, type AnchorType } from "./ahLedgerMath.ts";
 import type { Config } from "../config/config.types.ts";
 
 /**
@@ -107,6 +107,6 @@ function publishAnchorMarker(client: AsyncMqttClient | undefined, type: AnchorTy
     return;
   }
   // Line protocol with a tag so Grafana can split by kind; markers are rare, so a failure is worth a log.
-  const line = `soc_anchors,type=${type} value=1`;
-  client.publish("soc_anchors", line).catch(error => warnLog("Failed to publish soc_anchors marker", type, error));
+  const line = `${SOC_ANCHORS_MEASUREMENT},type=${type} value=1`;
+  client.publish(SOC_ANCHORS_MEASUREMENT, line).catch(error => warnLog("Failed to publish soc_anchors marker", type, error));
 }

--- a/backend/src/battery/anchorDetection.ts
+++ b/backend/src/battery/anchorDetection.ts
@@ -108,5 +108,7 @@ function publishAnchorMarker(client: AsyncMqttClient | undefined, type: AnchorTy
   }
   // Line protocol with a tag so Grafana can split by kind; markers are rare, so a failure is worth a log.
   const line = `${SOC_ANCHORS_MEASUREMENT},type=${type} value=1`;
-  client.publish(SOC_ANCHORS_MEASUREMENT, line).catch(error => warnLog("Failed to publish soc_anchors marker", type, error));
+  client
+    .publish(SOC_ANCHORS_MEASUREMENT, line)
+    .catch(error => warnLog("Failed to publish soc_anchors marker", type, error));
 }

--- a/backend/src/battery/anchorDetection.ts
+++ b/backend/src/battery/anchorDetection.ts
@@ -102,7 +102,10 @@ export function anchorDetection({
 }
 
 function publishAnchorMarker(client: AsyncMqttClient | undefined, type: AnchorType) {
-  if (!client || !client.connected) return;
+  if (!client || !client.connected) {
+    warnLog("MQTT not connected — soc_anchors marker lost; restore will fall back to the voltage queries", type);
+    return;
+  }
   // Line protocol with a tag so Grafana can split by kind; markers are rare, so a failure is worth a log.
   const line = `soc_anchors,type=${type} value=1`;
   client.publish("soc_anchors", line).catch(error => warnLog("Failed to publish soc_anchors marker", type, error));

--- a/backend/src/battery/anchorDetection.ts
+++ b/backend/src/battery/anchorDetection.ts
@@ -1,0 +1,109 @@
+import { type Accessor, createEffect, createSignal, untrack } from "solid-js";
+import type { AsyncMqttClient } from "async-mqtt";
+import { useFromMqttProvider } from "../mqttValues/MQTTValuesProvider.ts";
+import { reactiveBatteryVoltage, reactiveBatteryVoltageTime } from "../mqttValues/mqttHelpers.ts";
+import { fullConditionMet, emptyConditionMet } from "./anchorConditions.ts";
+import { warnLog } from "../utilities/logging.ts";
+import type { AnchorType } from "./ahLedgerMath.ts";
+import type { Config } from "../config/config.types.ts";
+
+/**
+ * Edge-detects the three anchor kinds from live voltage + 1-min-smoothed hall amps and latches the
+ * time of each most-recent event (one per event, not once per sample — so the Ah ledger re-anchors and
+ * re-queries the DB integral only when something actually happened). Every detection also drops a
+ * marker into the `soc_anchors` measurement so a later restart can restore the anchor directly.
+ *
+ * Re-arm hysteresis keeps a pack hovering at a threshold from chattering: full re-arms below
+ * full − 0.5 V, empty above empty + 0.5 V, soft-empty above its voltage + 0.5 V (the last per spec).
+ * On the first reading we only arm the conditions we are clearly NOT already in, so a restart while
+ * sitting at float/full doesn't emit a spurious marker (the DB restore covers the current state).
+ */
+export function anchorDetection({
+  config,
+  smoothedBatteryCurrentAmps,
+}: {
+  config: Accessor<Config>;
+  smoothedBatteryCurrentAmps: Accessor<number | undefined>;
+}) {
+  const { mqttClient } = useFromMqttProvider();
+  const [lastFullEventAt, setLastFullEventAt] = createSignal<number | undefined>(undefined);
+  const [lastEmptyEventAt, setLastEmptyEventAt] = createSignal<number | undefined>(undefined);
+  const [lastSoftEmptyEventAt, setLastSoftEmptyEventAt] = createSignal<number | undefined>(undefined);
+
+  let primed = false;
+  let armedFull = false;
+  let armedEmpty = false;
+  let armedSoftEmpty = false;
+  let previousVoltage: number | undefined;
+
+  createEffect(() => {
+    const voltage = reactiveBatteryVoltage();
+    const eventTime = reactiveBatteryVoltageTime();
+    const smoothedAmps = smoothedBatteryCurrentAmps();
+    if (voltage == undefined || eventTime == undefined) return;
+
+    const fullBatteryVoltage = config().full_battery_voltage;
+    const stopChargingBelowCurrent = config().stop_charging_below_current;
+    const batteryEmptyAt = config().soc_calculations.battery_empty_at;
+    const softEmpty = config().soc_calculations.ah_ledger.soft_empty;
+
+    if (!primed) {
+      primed = true;
+      previousVoltage = voltage;
+      // Arm only where we're clearly outside the condition, so booting mid-full/at-rest stays quiet.
+      armedFull = voltage < fullBatteryVoltage - 0.5;
+      armedEmpty = voltage > batteryEmptyAt + 0.5;
+      armedSoftEmpty = voltage > softEmpty.voltage + 0.5;
+      return;
+    }
+
+    // Full — level condition, needs the smoothed current. Re-arm is current-independent.
+    if (armedFull) {
+      if (
+        smoothedAmps != undefined &&
+        fullConditionMet(voltage, smoothedAmps, fullBatteryVoltage, stopChargingBelowCurrent)
+      ) {
+        armedFull = false;
+        setLastFullEventAt(eventTime);
+        publishAnchorMarker(untrack(mqttClient), "full");
+      }
+    } else if (voltage < fullBatteryVoltage - 0.5) {
+      armedFull = true;
+    }
+
+    // Empty — level condition on voltage only (hall current not required, unchanged from the Wh path).
+    if (armedEmpty) {
+      if (emptyConditionMet(voltage, batteryEmptyAt)) {
+        armedEmpty = false;
+        setLastEmptyEventAt(eventTime);
+        publishAnchorMarker(untrack(mqttClient), "empty");
+      }
+    } else if (voltage > batteryEmptyAt + 0.5) {
+      armedEmpty = true;
+    }
+
+    // Soft-empty — a downward voltage crossing while nearly at rest.
+    if (armedSoftEmpty) {
+      const crossedDown =
+        previousVoltage != undefined && previousVoltage > softEmpty.voltage && voltage <= softEmpty.voltage;
+      if (crossedDown && smoothedAmps != undefined && Math.abs(smoothedAmps) < softEmpty.max_abs_amps) {
+        armedSoftEmpty = false;
+        setLastSoftEmptyEventAt(eventTime);
+        publishAnchorMarker(untrack(mqttClient), "soft_empty");
+      }
+    } else if (voltage > softEmpty.voltage + 0.5) {
+      armedSoftEmpty = true;
+    }
+
+    previousVoltage = voltage;
+  });
+
+  return { lastFullEventAt, lastEmptyEventAt, lastSoftEmptyEventAt };
+}
+
+function publishAnchorMarker(client: AsyncMqttClient | undefined, type: AnchorType) {
+  if (!client || !client.connected) return;
+  // Line protocol with a tag so Grafana can split by kind; markers are rare, so a failure is worth a log.
+  const line = `soc_anchors,type=${type} value=1`;
+  client.publish("soc_anchors", line).catch(error => warnLog("Failed to publish soc_anchors marker", type, error));
+}

--- a/backend/src/battery/queryChargeIntegral.ts
+++ b/backend/src/battery/queryChargeIntegral.ts
@@ -1,0 +1,34 @@
+import type Influx from "influx";
+import { logLog } from "../utilities/logging.ts";
+
+/**
+ * Charge (amp-hours) integrated from hall sensor 2 since `fromMs`, reconstructed from the RAW mV field
+ * so it survives calibration changes and deploys (raw_voltage_mv_2 has full history; a calculated_current
+ * field would only exist from the day this ships). The inner query derives amps from the same formula the
+ * live signal uses, the outer integrates it — integral(amps, 1h) is directly amp-hours (charge positive).
+ * We start at fromMs + 1 to exclude the exact anchor sample.
+ */
+export async function queryChargeIntegral(
+  db: Influx.InfluxDB,
+  fromMs: number,
+  zeroCurrentMillivolts: number,
+  millivoltsPerAmpere: number
+): Promise<number> {
+  const query =
+    `SELECT integral("amps", 1h) as charge FROM ` +
+    `(SELECT ("raw_voltage_mv_2" - ${zeroCurrentMillivolts}) / ${millivoltsPerAmpere} AS amps ` +
+    `FROM "current_values" WHERE time >= ${fromMs + 1}ms)`;
+  logLog("Querying Ah ledger charge integral from", new Date(fromMs).toISOString());
+
+  const results = await db.query<{ charge: number | null }>(query);
+  const charge = results[0]?.charge;
+
+  if (charge != null && !isNaN(charge)) {
+    logLog("Got Ah ledger charge integral:", charge, "Ah from", new Date(fromMs).toISOString());
+    return charge;
+  }
+
+  // No samples yet (e.g. we just anchored) — 0 Ah accumulated is the right answer.
+  logLog("No charge data found for Ah ledger from", new Date(fromMs).toISOString());
+  return 0;
+}

--- a/backend/src/battery/socAnchorRestore.ts
+++ b/backend/src/battery/socAnchorRestore.ts
@@ -36,7 +36,9 @@ async function queryLastAnchorMarker(
 ): Promise<number | undefined> {
   if (!database) return undefined;
   try {
-    const [response] = await database.query(`SELECT last("value") FROM "${SOC_ANCHORS_MEASUREMENT}" WHERE "type" = '${type}'`);
+    const [response] = await database.query(
+      `SELECT last("value") FROM "${SOC_ANCHORS_MEASUREMENT}" WHERE "type" = '${type}'`
+    );
     const timeOfLastMarker = (response as { time?: { getNanoTime: () => number } })?.time?.getNanoTime?.();
     if (timeOfLastMarker !== undefined && !isNaN(timeOfLastMarker)) {
       return Math.round(timeOfLastMarker / 1000 / 1000);

--- a/backend/src/battery/socAnchorRestore.ts
+++ b/backend/src/battery/socAnchorRestore.ts
@@ -2,7 +2,7 @@ import type Influx from "influx";
 import { type Accessor, createMemo, createResource } from "solid-js";
 import type { InfluxClientAccessor } from "./useDatabasePower.ts";
 import { warnLog } from "../utilities/logging.ts";
-import type { AnchorType } from "./ahLedgerMath.ts";
+import { SOC_ANCHORS_MEASUREMENT, type AnchorType } from "./ahLedgerMath.ts";
 
 /**
  * Restores the Ah ledger's anchor times across restarts, preferring the explicit `soc_anchors` markers
@@ -36,7 +36,7 @@ async function queryLastAnchorMarker(
 ): Promise<number | undefined> {
   if (!database) return undefined;
   try {
-    const [response] = await database.query(`SELECT last("value") FROM "soc_anchors" WHERE "type" = '${type}'`);
+    const [response] = await database.query(`SELECT last("value") FROM "${SOC_ANCHORS_MEASUREMENT}" WHERE "type" = '${type}'`);
     const timeOfLastMarker = (response as { time?: { getNanoTime: () => number } })?.time?.getNanoTime?.();
     if (timeOfLastMarker !== undefined && !isNaN(timeOfLastMarker)) {
       return Math.round(timeOfLastMarker / 1000 / 1000);

--- a/backend/src/battery/socAnchorRestore.ts
+++ b/backend/src/battery/socAnchorRestore.ts
@@ -1,0 +1,50 @@
+import type Influx from "influx";
+import { type Accessor, createMemo, createResource } from "solid-js";
+import type { InfluxClientAccessor } from "./useDatabasePower.ts";
+import { warnLog } from "../utilities/logging.ts";
+import type { AnchorType } from "./ahLedgerMath.ts";
+
+/**
+ * Restores the Ah ledger's anchor times across restarts, preferring the explicit `soc_anchors` markers
+ * this build writes and falling back to the Wh system's voltage-based queries when no marker exists yet
+ * (the first deploy, before any marker has been dropped). Soft-empty has no voltage fallback — it only
+ * exists once a marker has been written, which is fine (the ledger just uses full/empty until then).
+ */
+export function socAnchorRestore({
+  influxClient,
+  databaseFullFallbackAt,
+  databaseEmptyFallbackAt,
+}: {
+  influxClient: InfluxClientAccessor;
+  databaseFullFallbackAt: Accessor<number | undefined>;
+  databaseEmptyFallbackAt: Accessor<number | undefined>;
+}) {
+  const [fullMarkerAt] = createResource(influxClient, database => queryLastAnchorMarker(database, "full"));
+  const [emptyMarkerAt] = createResource(influxClient, database => queryLastAnchorMarker(database, "empty"));
+  const [softEmptyMarkerAt] = createResource(influxClient, database => queryLastAnchorMarker(database, "soft_empty"));
+
+  return {
+    restoredFullAt: createMemo(() => fullMarkerAt() ?? databaseFullFallbackAt()),
+    restoredEmptyAt: createMemo(() => emptyMarkerAt() ?? databaseEmptyFallbackAt()),
+    restoredSoftEmptyAt: createMemo(() => softEmptyMarkerAt()),
+  };
+}
+
+async function queryLastAnchorMarker(
+  database: Influx.InfluxDB | undefined,
+  type: AnchorType
+): Promise<number | undefined> {
+  if (!database) return undefined;
+  try {
+    const [response] = await database.query(`SELECT last("value") FROM "soc_anchors" WHERE "type" = '${type}'`);
+    const timeOfLastMarker = (response as { time?: { getNanoTime: () => number } })?.time?.getNanoTime?.();
+    if (timeOfLastMarker !== undefined && !isNaN(timeOfLastMarker)) {
+      return Math.round(timeOfLastMarker / 1000 / 1000);
+    }
+    // No marker for this type yet (e.g. first deploy) — caller falls back to the voltage-based query.
+    return undefined;
+  } catch (error) {
+    warnLog(`Failed to restore last ${type} anchor from soc_anchors; falling back to voltage query`, error);
+    return undefined;
+  }
+}

--- a/backend/src/battery/useAhLedger.ts
+++ b/backend/src/battery/useAhLedger.ts
@@ -4,9 +4,8 @@ import type { InfluxClientAccessor } from "./useDatabasePower.ts";
 import { anchorDetection } from "./anchorDetection.ts";
 import { socAnchorRestore } from "./socAnchorRestore.ts";
 import { ahLedger } from "./ahLedger.ts";
-import type { AnchorType } from "./ahLedgerMath.ts";
+import type { LedgerAnchor } from "./ahLedgerMath.ts";
 
-type LedgerAnchor = { at: number; soc: number; type: AnchorType };
 
 /**
  * Wires the Ah ledger together: live edge detection + marker publishing, cross-restart restore from

--- a/backend/src/battery/useAhLedger.ts
+++ b/backend/src/battery/useAhLedger.ts
@@ -6,7 +6,6 @@ import { socAnchorRestore } from "./socAnchorRestore.ts";
 import { ahLedger } from "./ahLedger.ts";
 import type { LedgerAnchor } from "./ahLedgerMath.ts";
 
-
 /**
  * Wires the Ah ledger together: live edge detection + marker publishing, cross-restart restore from
  * soc_anchors (voltage-based fallback for full/empty), the single "latest anchor of any type" the ledger

--- a/backend/src/battery/useAhLedger.ts
+++ b/backend/src/battery/useAhLedger.ts
@@ -1,0 +1,78 @@
+import { type Accessor, createMemo } from "solid-js";
+import type { get_config_object } from "../config/config.ts";
+import type { InfluxClientAccessor } from "./useDatabasePower.ts";
+import { anchorDetection } from "./anchorDetection.ts";
+import { socAnchorRestore } from "./socAnchorRestore.ts";
+import { ahLedger } from "./ahLedger.ts";
+import type { AnchorType } from "./ahLedgerMath.ts";
+
+type LedgerAnchor = { at: number; soc: number; type: AnchorType };
+
+/**
+ * Wires the Ah ledger together: live edge detection + marker publishing, cross-restart restore from
+ * soc_anchors (voltage-based fallback for full/empty), the single "latest anchor of any type" the ledger
+ * hangs off, and the ledger itself. Consumes the hall amps *signals* (not the ADC) so it stays importable
+ * on machines without the arm64 sensor addon.
+ */
+export function useAhLedger({
+  configSignal,
+  influxClient,
+  batteryCurrentAmps,
+  smoothedBatteryCurrentAmps,
+  databaseFullFallbackAt,
+  databaseEmptyFallbackAt,
+}: {
+  configSignal: Awaited<ReturnType<typeof get_config_object>>;
+  influxClient: InfluxClientAccessor;
+  batteryCurrentAmps: Accessor<{ value: number; time: number } | undefined>;
+  smoothedBatteryCurrentAmps: Accessor<number | undefined>;
+  databaseFullFallbackAt: Accessor<number | undefined>;
+  databaseEmptyFallbackAt: Accessor<number | undefined>;
+}) {
+  const [config] = configSignal;
+
+  const { lastFullEventAt, lastEmptyEventAt, lastSoftEmptyEventAt } = anchorDetection({
+    config,
+    smoothedBatteryCurrentAmps,
+  });
+  const { restoredFullAt, restoredEmptyAt, restoredSoftEmptyAt } = socAnchorRestore({
+    influxClient,
+    databaseFullFallbackAt,
+    databaseEmptyFallbackAt,
+  });
+
+  const fullAt = createMemo(() => laterOf(lastFullEventAt(), restoredFullAt()));
+  const emptyAt = createMemo(() => laterOf(lastEmptyEventAt(), restoredEmptyAt()));
+  const softEmptyAt = createMemo(() => laterOf(lastSoftEmptyEventAt(), restoredSoftEmptyAt()));
+
+  // The anchor the ledger hangs off: whichever kind fired most recently, tagged with its known SOC.
+  // equals-guarded so unrelated config writes (the online drain/capacity persist, schedule edits, …)
+  // can't churn the DB integral query or spuriously re-anchor.
+  const latestAnchor = createMemo<LedgerAnchor | undefined>(
+    () => {
+      const softEmptySocPercent = config().soc_calculations.ah_ledger.soft_empty.soc_percent;
+      const candidates: LedgerAnchor[] = [];
+      const fullTime = fullAt();
+      const emptyTime = emptyAt();
+      const softEmptyTime = softEmptyAt();
+      if (fullTime != undefined) candidates.push({ at: fullTime, soc: 100, type: "full" });
+      if (emptyTime != undefined) candidates.push({ at: emptyTime, soc: 0, type: "empty" });
+      if (softEmptyTime != undefined)
+        candidates.push({ at: softEmptyTime, soc: softEmptySocPercent, type: "soft_empty" });
+      if (!candidates.length) return undefined;
+      return candidates.reduce((latest, candidate) => (candidate.at > latest.at ? candidate : latest));
+    },
+    undefined,
+    { equals: (a, b) => a?.at === b?.at && a?.soc === b?.soc && a?.type === b?.type }
+  );
+
+  const { socAh } = ahLedger({ configSignal, influxClient, batteryCurrentAmps, latestAnchor });
+
+  return { socAh };
+}
+
+function laterOf(a: number | undefined, b: number | undefined): number | undefined {
+  if (a == undefined) return b;
+  if (b == undefined) return a;
+  return Math.max(a, b);
+}

--- a/backend/src/battery/useBatteryValues.ts
+++ b/backend/src/battery/useBatteryValues.ts
@@ -5,15 +5,29 @@ import { get_config_object } from "../config/config.ts";
 import { batteryCalculationsDependingOnUnknowns } from "./batteryCalculationsDependingOnUnknowns.ts";
 import { iterativelyFindSocParameters } from "./iterativelyFindSocParameters.ts";
 import { reportSOCToMqtt } from "./reportSOCToMqtt.ts";
-import { errorLog } from "../utilities/logging.ts";
+import { useAhLedger } from "./useAhLedger.ts";
+import { errorLog, warnLog } from "../utilities/logging.ts";
 
 export function useBatteryValues(
   configSignal: Awaited<ReturnType<typeof get_config_object>>,
-  currentPower: Accessor<{ value: number; time: number } | undefined>
+  {
+    currentPower,
+    batteryCurrentAmps,
+    smoothedBatteryCurrentAmps,
+  }: {
+    /** Instantaneous battery power from hall sensor 2 (drives the Wh ledger). */
+    currentPower: Accessor<{ value: number; time: number } | undefined>;
+    /** Instantaneous battery amps from hall sensor 2 (drives the Ah ledger). */
+    batteryCurrentAmps: Accessor<{ value: number; time: number } | undefined>;
+    /** 1-min-smoothed hall amps (drives full/soft-empty anchor detection). */
+    smoothedBatteryCurrentAmps: Accessor<number | undefined>;
+  }
 ) {
   const [config] = configSignal;
-  const { lastBatterySeenFullSinceProgramStart, lastBatterySeenEmptySinceProgramStart } =
-    useLastFullAndEmpty(configSignal);
+  const { lastBatterySeenFullSinceProgramStart, lastBatterySeenEmptySinceProgramStart } = useLastFullAndEmpty(
+    configSignal,
+    smoothedBatteryCurrentAmps
+  );
   const { influxClient, batteryWasLastFullAtAccordingToDatabase, batteryWasLastEmptyAtAccordingToDatabase } =
     useDatabasePower(configSignal);
 
@@ -79,6 +93,43 @@ export function useBatteryValues(
     return (sinceFull! + sinceEmpty!) / 2;
   });
 
+  // Consumers (planner, sell/buy, ws) get a sane [0,100]; the raw averageSOC keeps flowing to InfluxDB
+  // (reportSOCToMqtt) unclamped so the drift stays visible in Grafana.
+  const clampedAverageSOC = createMemo(() => {
+    const average = averageSOC();
+    if (average == undefined) return undefined;
+    return Math.max(0, Math.min(100, average));
+  });
+
+  // Health signal: the 30-min fitter force-equalizes soc_since_full/empty, so a persistent gap means the
+  // Wh baseline is drifting between fits. Edge-triggered to avoid spamming while diverged.
+  let whLedgersDiverged = false;
+  createEffect(() => {
+    const sinceFull = socSinceFull();
+    const sinceEmpty = socSinceEmpty();
+    if (sinceFull == undefined || sinceEmpty == undefined) return;
+    const divergencePp = Math.abs(sinceFull - sinceEmpty);
+    if (divergencePp > 5) {
+      if (!whLedgersDiverged) {
+        whLedgersDiverged = true;
+        warnLog(
+          `Wh SOC health: soc_since_full (${sinceFull}%) and soc_since_empty (${sinceEmpty}%) diverge by ${divergencePp.toFixed(1)} pp (>5)`
+        );
+      }
+    } else {
+      whLedgersDiverged = false;
+    }
+  });
+
+  const { socAh } = useAhLedger({
+    configSignal,
+    influxClient,
+    batteryCurrentAmps,
+    smoothedBatteryCurrentAmps,
+    databaseFullFallbackAt: batteryWasLastFullAtAccordingToDatabase,
+    databaseEmptyFallbackAt: batteryWasLastEmptyAtAccordingToDatabase,
+  });
+
   reportSOCToMqtt({
     config,
     averageSOC,
@@ -96,5 +147,7 @@ export function useBatteryValues(
     assumedCapacity,
     assumedParasiticConsumption,
     averageSOC,
+    clampedAverageSOC,
+    socAh,
   };
 }

--- a/backend/src/battery/useLastFullAndEmpty.ts
+++ b/backend/src/battery/useLastFullAndEmpty.ts
@@ -1,17 +1,22 @@
 import { get_config_object } from "../config/config.ts";
-import { createMemo } from "solid-js";
-import {
-  reactiveBatteryCurrent,
-  reactiveBatteryVoltage,
-  reactiveBatteryVoltageTime,
-} from "../mqttValues/mqttHelpers.ts";
+import { type Accessor, createMemo } from "solid-js";
+import { reactiveBatteryVoltage, reactiveBatteryVoltageTime } from "../mqttValues/mqttHelpers.ts";
+import { fullConditionMet, emptyConditionMet } from "./anchorConditions.ts";
 
-export function useLastFullAndEmpty([config]: Awaited<ReturnType<typeof get_config_object>>) {
+/**
+ * Live "last seen full / empty" for the Wh baseline. Full now keys off the 1-min-smoothed HALL current
+ * (sensor 2) rather than the inverter's battery_current, which under-reads by omitting self-consumption
+ * and so let the pack look "still charging" past the real taper. Empty is unchanged (voltage only).
+ */
+export function useLastFullAndEmpty(
+  [config]: Awaited<ReturnType<typeof get_config_object>>,
+  smoothedBatteryCurrentAmps: Accessor<number | undefined>
+) {
   const haveSeenBatteryFullAt = createMemo<number | undefined>(prev => {
     const voltage = reactiveBatteryVoltage();
-    const current = reactiveBatteryCurrent();
-    if (voltage == undefined || current == undefined) return prev;
-    if (voltage >= config().full_battery_voltage && current < config().stop_charging_below_current) {
+    const smoothedAmps = smoothedBatteryCurrentAmps();
+    if (voltage == undefined || smoothedAmps == undefined) return prev;
+    if (fullConditionMet(voltage, smoothedAmps, config().full_battery_voltage, config().stop_charging_below_current)) {
       return reactiveBatteryVoltageTime();
     }
     return prev;
@@ -20,7 +25,7 @@ export function useLastFullAndEmpty([config]: Awaited<ReturnType<typeof get_conf
   const haveSeenBatteryEmptyAt = createMemo<number | undefined>(prev => {
     const voltage = reactiveBatteryVoltage();
     if (voltage == undefined) return prev;
-    if (voltage <= config().soc_calculations.battery_empty_at) {
+    if (emptyConditionMet(voltage, config().soc_calculations.battery_empty_at)) {
       return reactiveBatteryVoltageTime();
     }
     return prev;

--- a/backend/src/buying/useShouldBuyPower.ts
+++ b/backend/src/buying/useShouldBuyPower.ts
@@ -8,7 +8,7 @@ import { useBatteryValuesProvider } from "../battery/BatteryValuesProvider.ts";
 import type { Config } from "../config/config.types.ts";
 
 export function useShouldBuyPower({ config }: { config: Accessor<Config> }) {
-  const { averageSOC, assumedParasiticConsumption } = useBatteryValuesProvider();
+  const { clampedAverageSOC, assumedParasiticConsumption } = useBatteryValuesProvider();
   const scheduleOutput = createMemo(
     mapArray(
       () => Object.keys(config().scheduled_power_buying.schedule),
@@ -49,7 +49,7 @@ export function useShouldBuyPower({ config }: { config: Accessor<Config> }) {
   let hitSOCLimit = false;
 
   const powerFromSchedule = createMemo(() => {
-    const soc = averageSOC();
+    const soc = clampedAverageSOC();
     if (soc === undefined) return;
     const { only_buy_below_soc, start_buying_again_below_soc } = config().scheduled_power_buying;
     const limitToUse = hitSOCLimit ? start_buying_again_below_soc : only_buy_below_soc;

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -93,6 +93,20 @@ export const default_config: Config = {
       capacity: 19.2 * 12 * 3 * 16,
       parasitic_consumption: 315,
     },
+    // Validated offline on 3 months of hall-sensor-2 data (Phase 0). drain_a is seasonal (~0.7 A in
+    // spring, ~2.8 A in summer) which is why it is tracked online rather than hard-coded.
+    ah_ledger: {
+      capacity_ah: 1240,
+      drain_a: 2.8,
+      v_discharge: 51.63,
+      v_charge: 53.79,
+      drain_ema_tau_days: 7,
+      soft_empty: {
+        voltage: 49,
+        max_abs_amps: 30,
+        soc_percent: 0.4,
+      },
+    },
   },
   current_measuring: {
     table: "current_values",
@@ -134,10 +148,12 @@ export const default_config: Config = {
 };
 
 /**
- * Top-level keys merge shallowly, but automatic_trading and elpatron_switching merge one level
- * deeper: knobs get added over time, and a config.json written before a knob existed must still
- * pick up its default (the planner and the elpatron load model do raw arithmetic on these — a
- * missing knob would silently NaN projections).
+ * Top-level keys merge shallowly, but automatic_trading, elpatron_switching and soc_calculations
+ * merge one level deeper: knobs get added over time, and a config.json written before a knob
+ * existed must still pick up its default (the planner, the elpatron load model and the SOC
+ * ledgers do raw arithmetic on these — a missing knob would silently NaN every projection).
+ * soc_calculations.ah_ledger (and its soft_empty) is the newest such section, so a config
+ * predating it still boots with the validated defaults.
  */
 function mergeWithDefaults(partial: Partial<Config>): Config {
   return {
@@ -145,6 +161,22 @@ function mergeWithDefaults(partial: Partial<Config>): Config {
     ...partial,
     automatic_trading: { ...default_config.automatic_trading, ...partial.automatic_trading },
     elpatron_switching: { ...default_config.elpatron_switching, ...partial.elpatron_switching },
+    soc_calculations: {
+      ...default_config.soc_calculations,
+      ...partial.soc_calculations,
+      current_state: {
+        ...default_config.soc_calculations.current_state,
+        ...partial.soc_calculations?.current_state,
+      },
+      ah_ledger: {
+        ...default_config.soc_calculations.ah_ledger,
+        ...partial.soc_calculations?.ah_ledger,
+        soft_empty: {
+          ...default_config.soc_calculations.ah_ledger.soft_empty,
+          ...partial.soc_calculations?.ah_ledger?.soft_empty,
+        },
+      },
+    },
   };
 }
 

--- a/backend/src/config/config.types.ts
+++ b/backend/src/config/config.types.ts
@@ -140,6 +140,35 @@ export type Config = {
       parasitic_consumption: number;
       capacity: number;
     };
+    /**
+     * Coulomb-counting (Ah) SOC ledger — the Phase 1 shadow of the Wh system above. Anchored at the
+     * latest full/empty/soft-empty event and integrated from hall sensor 2 amps:
+     *   SOC = anchor_soc + (∫amps·dt − drain_a·elapsed_h) / capacity_ah · 100
+     * `drain_a` (sensor zero-bias + parasitic, seasonal) and `capacity_ah` are tracked online (EMA)
+     * and persisted here across restarts, exactly like `current_state` above.
+     */
+    ah_ledger: {
+      /** Usable pack capacity in amp-hours (16S LiFePO4). Online-tracked from deep full↔empty spans. */
+      capacity_ah: number;
+      /** Constant amp offset subtracted each hour (hall zero-bias + parasitic). Online-tracked, seasonal. */
+      drain_a: number;
+      /** Mean discharge-branch terminal voltage (Phase 0 V-bar). Recorded for reference; unused in Phase 1. */
+      v_discharge: number;
+      /** Mean charge-branch terminal voltage (Phase 0 V-bar). Recorded for reference; unused in Phase 1. */
+      v_charge: number;
+      /** EMA time constant (days) for the drain update weight w = 1 − exp(−dt_days / tau). */
+      drain_ema_tau_days: number;
+      /**
+       * Soft-empty anchor — the pack often only drains to ~49 V, not the 46 V hard empty. A downward
+       * crossing of `voltage` while nearly at rest (|amps| < max_abs_amps) anchors the Ah ledger (only)
+       * at `soc_percent`.
+       */
+      soft_empty: {
+        voltage: number;
+        max_abs_amps: number;
+        soc_percent: number;
+      };
+    };
   };
   elpatron_switching: {
     /** Let this controller gate the water heater element by solar (write-gpio to the heating pi) */

--- a/backend/src/currentMeasuring/useCurrentMeasuring.ts
+++ b/backend/src/currentMeasuring/useCurrentMeasuring.ts
@@ -3,6 +3,7 @@ import { type Accessor, createEffect, createMemo, createSignal, onCleanup, type 
 import { errorLog } from "../utilities/logging.ts";
 import { useFromMqttProvider } from "../mqttValues/MQTTValuesProvider.ts";
 import { useAverageCurrent } from "./useAverageCurrent.ts";
+import { useSmoothedCurrent } from "./useSmoothedCurrent.ts";
 import { reactiveBatteryVoltage } from "../mqttValues/mqttHelpers.ts";
 import type { Config } from "../config/config.types.ts";
 
@@ -27,23 +28,39 @@ export function useCurrentMeasuring(config: Accessor<Config>, sensor2: boolean) 
   );
 
   const averagedMeasurement = useAverageCurrent({ rawMeasurement, config });
-  const calculatedPowerFromAmpMeter = createMemo(() => {
+  // Calibrated amps (positive = charging). Split out of the power calc so the Ah ledger and anchor
+  // detection can consume the current directly instead of dividing power back by voltage.
+  const calculatedCurrentFromAmpMeter = createMemo(() => {
     const measurementValue = rawMeasurement();
-    const batteryVoltage = reactiveBatteryVoltage();
-    if (!measurementValue || batteryVoltage == undefined) return;
+    if (!measurementValue) return;
     const calculatedCurrent = (measurementValue.value - zeroCurrentMillivolts()) / milliVoltsPerAmpere();
-    return { value: calculatedCurrent * batteryVoltage, time: measurementValue.time };
+    return { value: calculatedCurrent, time: measurementValue.time };
+  });
+  const calculatedPowerFromAmpMeter = createMemo(() => {
+    const current = calculatedCurrentFromAmpMeter();
+    const batteryVoltage = reactiveBatteryVoltage();
+    if (!current || batteryVoltage == undefined) return;
+    return { value: current.value * batteryVoltage, time: current.time };
   });
   const averagedPower = useAverageCurrent({ rawMeasurement: calculatedPowerFromAmpMeter, config });
+  const averagedCurrent = useAverageCurrent({ rawMeasurement: calculatedCurrentFromAmpMeter, config });
+  // 1-min trailing mean for anchor detection (full/soft-empty), immune to single-sample ADC noise.
+  const smoothedCurrent = useSmoothedCurrent({ rawCurrent: calculatedCurrentFromAmpMeter });
 
   createEffect(() => reportToMqtt(rawMeasurement()?.value, config, `raw_voltage_mv${sensor2 ? "_2" : ""}`));
   createEffect(() => reportToMqtt(averagedMeasurement(), config, `voltage_mv_averaged${sensor2 ? "_2" : ""}`));
   createEffect(() => reportToMqtt(averagedPower(), config, `calculated_power${sensor2 ? "_2" : ""}`));
+  // Sensor 1 is unchanged — only sensor 2 (the battery current truth source) publishes calculated_current_2.
+  if (sensor2) {
+    createEffect(() => reportToMqtt(averagedCurrent(), config, "calculated_current_2"));
+  }
 
   return {
     voltageSagMillivoltsRaw: rawMeasurement,
     voltageSagMillivoltsAveraged: averagedMeasurement,
     calculatedPowerFromAmpMeter,
+    calculatedCurrentFromAmpMeter,
+    smoothedCurrent,
   };
 }
 

--- a/backend/src/currentMeasuring/useSmoothedCurrent.ts
+++ b/backend/src/currentMeasuring/useSmoothedCurrent.ts
@@ -1,0 +1,31 @@
+import { type Accessor, createMemo } from "solid-js";
+
+/**
+ * Trailing rolling mean of an amp signal over `windowMs` (default 60 s). Anchor detection wants a
+ * 1-min-smoothed hall current so a single noisy ADC sample can't declare the pack full or trip a
+ * soft-empty crossing. Kept O(1) per sample with a running sum. Emits undefined until the first
+ * sample arrives, then always the mean of whatever falls inside the window.
+ */
+export function useSmoothedCurrent({
+  rawCurrent,
+  windowMs = 60_000,
+}: {
+  rawCurrent: Accessor<{ value: number; time: number } | undefined>;
+  windowMs?: number;
+}): Accessor<number | undefined> {
+  const samples: { value: number; time: number }[] = [];
+  let runningSum = 0;
+
+  return createMemo<number | undefined>(prev => {
+    const current = rawCurrent();
+    if (!current) return prev;
+    samples.push(current);
+    runningSum += current.value;
+    const cutoff = current.time - windowMs;
+    while (samples.length > 1 && samples[0].time < cutoff) {
+      runningSum -= samples[0].value;
+      samples.shift();
+    }
+    return runningSum / samples.length;
+  });
+}

--- a/backend/src/feeding/shouldSellPower.ts
+++ b/backend/src/feeding/shouldSellPower.ts
@@ -6,7 +6,7 @@ import { useBatteryValuesProvider } from "../battery/BatteryValuesProvider.ts";
 import type { Config } from "../config/config.types.ts";
 
 export function shouldSellPower(config: Accessor<Config>) {
-  const { averageSOC } = useBatteryValuesProvider();
+  const { clampedAverageSOC } = useBatteryValuesProvider();
   const scheduleOutput = createMemo(
     mapArray(
       () => Object.keys(config().scheduled_power_selling.schedule),
@@ -58,7 +58,7 @@ export function shouldSellPower(config: Accessor<Config>) {
   let hitLimit = false;
 
   const exportAmountForSelling = createMemo(() => {
-    const soc = averageSOC();
+    const soc = clampedAverageSOC();
     const voltage = reactiveBatteryVoltage();
     if (soc === undefined || voltage === undefined) return;
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -131,6 +131,7 @@ function main() {
                   assumedParasiticConsumption,
                   assumedCapacity,
                   clampedAverageSOC,
+                  socAh,
                 } = batteryValues;
 
                 return BatteryValuesProvider({
@@ -245,6 +246,8 @@ function main() {
                           socSinceFull,
                           // Frontend-facing SOC is clamped to [0,100]; the unclamped drift only goes to InfluxDB.
                           averageSOC: clampedAverageSOC,
+                          // Shadow Ah ledger, unclamped — diagnostics display only, nothing consumes it.
+                          socAh,
                           assumedCapacity,
                           assumedParasiticConsumption,
                           isCharging: () => isChargingOuterScope()?.()?.(),

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -114,7 +114,13 @@ function main() {
                   );
                 });
                 const currentPower = createMemo(() => currentReturn()?.sensor2.calculatedPowerFromAmpMeter?.());
-                const batteryValues = useBatteryValues(configResourceValue, currentPower);
+                const batteryCurrentAmps = createMemo(() => currentReturn()?.sensor2.calculatedCurrentFromAmpMeter?.());
+                const smoothedBatteryCurrentAmps = createMemo(() => currentReturn()?.sensor2.smoothedCurrent?.());
+                const batteryValues = useBatteryValues(configResourceValue, {
+                  currentPower,
+                  batteryCurrentAmps,
+                  smoothedBatteryCurrentAmps,
+                });
                 const {
                   totalLastEmpty,
                   totalLastFull,
@@ -124,6 +130,7 @@ function main() {
                   socSinceFull,
                   assumedParasiticConsumption,
                   assumedCapacity,
+                  clampedAverageSOC,
                 } = batteryValues;
 
                 return BatteryValuesProvider({
@@ -236,6 +243,8 @@ function main() {
                           voltageSagMillivoltsAveraged2: () => currentReturn()?.sensor2.voltageSagMillivoltsAveraged(),
                           socSinceEmpty,
                           socSinceFull,
+                          // Frontend-facing SOC is clamped to [0,100]; the unclamped drift only goes to InfluxDB.
+                          averageSOC: clampedAverageSOC,
                           assumedCapacity,
                           assumedParasiticConsumption,
                           isCharging: () => isChargingOuterScope()?.()?.(),

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -14,6 +14,7 @@ export default function Home() {
   const [hasHydrated, setHasHydrated] = createSignal(false);
   const [socSinceEmpty] = getBackendSyncedSignal<number>("socSinceEmpty");
   const [socSinceFull] = getBackendSyncedSignal<number>("socSinceFull");
+  const [socAh] = getBackendSyncedSignal<number>("socAh");
   const [voltageSagMillivoltsRaw] = getBackendSyncedSignal<{ value: number; time: number }>("voltageSagMillivoltsRaw");
   const [voltageSagMillivoltsAveraged] = getBackendSyncedSignal<number>("voltageSagMillivoltsAveraged");
   const [voltageSagMillivoltsRaw2] = getBackendSyncedSignal<{ value: number; time: number }>(
@@ -74,6 +75,10 @@ export default function Home() {
         </h4>
         Since full: {socSinceFull()}%<br />
         Since empty: {socSinceEmpty()}%<br />
+        <h4>Ah ledger (shadow, diagnostics)</h4>
+        SOC: {socAh()?.toFixed(2)}%<br />
+        capacity_ah: {config()?.soc_calculations?.ah_ledger?.capacity_ah}Ah, drain_a:{" "}
+        {config()?.soc_calculations?.ah_ledger?.drain_a}A<br />
         <br />
         <h4>Battery current measuring</h4>
         Raw: {voltageSagMillivoltsRaw()?.value}mv


### PR DESCRIPTION
## What

Adds a coulomb-counting (Ah) SOC ledger running in **shadow** beside the existing Wh system, plus the anchor-detection rework it was designed around. Validated offline on 3 months of hall-sensor history before writing this code (Phase 0/0.5 backfill studies).

### Shadow (no behavior change)
- `calculated_current_2` (calibrated sensor-2 amps) published to `current_values`
- Ah ledger anchored at the latest full/empty/soft-empty event; restores ∫amps across restarts via the `raw_voltage_mv_2` subquery (full history); publishes `soc_ah` **unclamped** to `soc_values`
- Online parameter tracking, forward-only (no retroactive SOC steps): drain EMA from full→full spans (tracks the seasonal hall zero drift, 0.7 A→2.8 A spring→summer), capacity EMA from deep full↔(soft-)empty spans; persisted in new config section `soc_calculations.ah_ledger`
- NEW soft-empty anchor: falling through 49 V at |I| < 30 A ⇒ ~0.4 % SOC (validated σ ≈ 1 pp across nights)

### Production behavior changes (deliberate)
- **Full detection now uses 1-min-smoothed hall amps** instead of the inverter's `battery_current`, which under-reads (omits the inverter's own ~150 W draw) and fired the anchor minutes early
- Every anchor detection writes a `soc_anchors,type=…` marker to Influx; startup restores from markers (voltage-query fallback on first deploy) — the old voltage-only restore could adopt aborted charges as full anchors
- Planner, runtime sell/buy gates, and ws consume SOC **clamped to [0,100]** (it currently ranges −1.6…107.4 %); raw values still flow to Influx for monitoring
- Edge-triggered warn when the Wh ledgers diverge > 5 pp

## Why

Measured on 30 d of production data: SOC drifts 0.9–4.2 pp/day between anchors (worst single error +7.2 pp ≈ 4.5 kWh phantom energy for the trader). Root causes: Wh bookkeeping absorbs the charge/discharge voltage asymmetry (53.8 V in / 51.6 V out) into a wandering "parasitic" fudge, and the hall sensor's zero drifts seasonally. Backfill replay shows the Ah ledger with tracked drain reaches ~0.4–1 pp median error at anchors (~2× better than Wh under identical conditions, and immune to the voltage asymmetry by construction).

## Test plan
- [x] `yarn typecheck` (only the 2 pre-existing ads1115 x64 errors)
- [x] `backend/src/battery/ahLedgerMath.selftest.ts` (29 assertions)
- [x] `backend/src/autoTrading/planner.selftest.ts`
- [x] `planPreview.ts` dry-run (with synthetic config on the dev VM)
- [ ] Shadow period on the pi: `soc_ah` vs `average_soc` at live anchors before any cutover

Rollback: `git checkout main && sudo systemctl restart mpi-15k-controller` — the new config section is additive and harmless to leave behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FShAMjWQEv4vQmqjcVqmxV