### PR TITLE
Model the water heater as a known load instead of forecasting it

### DIFF
--- a/backend/src/autoTrading/autoTrader.ts
+++ b/backend/src/autoTrading/autoTrader.ts
@@ -9,6 +9,7 @@ import { useBatteryValuesProvider } from "../battery/BatteryValuesProvider.ts";
 import { fetchPrices, type FetchedPrices, getCachedPrices } from "./priceService.ts";
 import { fetchSolarForecast } from "./solarForecast.ts";
 import { fetchConsumptionForecast } from "./consumptionForecast.ts";
+import { fetchElpatronForecast } from "./elpatronForecast.ts";
 import {
   type AutoTraderState,
   type AutoTraderStatus,
@@ -313,19 +314,32 @@ async function buildPlannerInput(
   soc: number
 ): Promise<PlannerInput> {
   const tradingConfig = cfg.automatic_trading;
+  const nowMs = Date.now();
   const solar = await fetchSolarForecast(
     tradingConfig.latitude,
     tradingConfig.longitude,
     tradingConfig.solar_model.watts_per_direct_radiation,
     tradingConfig.solar_model.watts_per_diffuse_radiation
   );
-  const consumption = await fetchConsumptionForecast(ctx.influxClient(), tradingConfig.fallback_house_load_watts);
+  // The water heater element is our own scheduled load, not a forecastable one: model it forward
+  // and strip its share out of the learned baseline so it isn't counted twice
+  const elpatron = await fetchElpatronForecast({
+    elpatronConfig: cfg.elpatron_switching,
+    influxClient: ctx.influxClient(),
+    solarWattsAt: solar.wattsAt,
+    nowMs,
+  });
+  const consumption = await fetchConsumptionForecast(
+    ctx.influxClient(),
+    tradingConfig.fallback_house_load_watts,
+    elpatron.armed ? cfg.elpatron_switching : undefined
+  );
   const { sells, buys } = userWindows(ctx, cfg);
   return {
-    nowMs: Date.now(),
+    nowMs,
     prices: prices.slots,
     solarWattsAt: solar.wattsAt,
-    houseLoadWattsAt: consumption.wattsAt,
+    houseLoadWattsAt: ms => consumption.wattsAt(ms) + elpatron.wattsAt(ms),
     parasiticWatts: ctx.assumedParasiticConsumption() || cfg.soc_calculations.current_state.parasitic_consumption,
     socPercent: soc,
     capacityWh: cfg.soc_calculations.current_state.capacity,

--- a/backend/src/autoTrading/consumptionForecast.ts
+++ b/backend/src/autoTrading/consumptionForecast.ts
@@ -9,7 +9,14 @@ export type ConsumptionForecast = {
   profile: number[];
 };
 
-let cache: ConsumptionForecast | undefined;
+/** Constants for stripping water-heater consumption out of the learned history (see below) */
+export type ElpatronHistoryKnobs = {
+  element_watts: number;
+  tank_wh_per_degree: number;
+  tank_cooling_degrees_per_hour: number;
+};
+
+let cache: (ConsumptionForecast & { elpatronSubtracted: boolean }) | undefined;
 
 function localHour(ms: number): number {
   return parseInt(
@@ -22,29 +29,56 @@ function localHour(ms: number): number {
  * Learn the house's typical consumption per local hour-of-day from the last 14 days of inverter data.
  * Median over days is used so that rare heavy loads (EV charging sessions) don't inflate the baseline —
  * those are exactly what the user handles manually via the extra-reserve knob.
+ *
+ * When `subtractElpatron` is set (the water heater element is currently armed — see
+ * elpatronForecast.ts), the element's share is stripped from each historical hour first, using the
+ * tank sensor: energy into the tank ≈ heat capacity × (ΔT + standing loss). The planner adds the
+ * element back as a modeled forward load, so leaving it in the baseline would double-count it.
+ * Not applied in stove season (element unarmed), where tank warming is the pellet stove's doing.
  */
 export async function fetchConsumptionForecast(
   influxClient: Influx.InfluxDB | undefined,
-  fallbackWatts: number
+  fallbackWatts: number,
+  subtractElpatron?: ElpatronHistoryKnobs
 ): Promise<ConsumptionForecast> {
   const maxAgeMs = 12 * 3600 * 1000;
-  if (cache && Date.now() - cache.fetchedAtMs < maxAgeMs && cache.source === "influx") return cache;
+  if (
+    cache &&
+    Date.now() - cache.fetchedAtMs < maxAgeMs &&
+    cache.source === "influx" &&
+    cache.elpatronSubtracted === !!subtractElpatron
+  ) {
+    return cache;
+  }
 
   let profile: number[] | undefined;
   if (influxClient) {
     try {
       // The influx client has no timeout of its own — don't let a hung connection stall callers forever
-      const rows = (await Promise.race([
+      const withTimeout = <T>(promise: Promise<T>) =>
+        Promise.race([
+          promise,
+          new Promise<never>((_, reject) => setTimeout(() => reject(new Error("InfluxDB query timed out")), 45_000)),
+        ]);
+      const rows = (await withTimeout(
         influxClient.query(
           `SELECT mean(ac_output_total_active_power) as house FROM "mpp-solar" WHERE time > now() - 14d GROUP BY time(1h)`
-        ),
-        new Promise((_, reject) => setTimeout(() => reject(new Error("InfluxDB query timed out")), 45_000)),
-      ])) as unknown as { time: { getNanoTime(): number }; house: number | null }[];
+        )
+      )) as unknown as { time: { getNanoTime(): number }; house: number | null }[];
+
+      const elpatronWByHourMs = subtractElpatron
+        ? await estimateElpatronHistory(influxClient, subtractElpatron, withTimeout)
+        : undefined;
+
       const byHour: number[][] = Array.from({ length: 24 }, () => []);
       for (const row of rows) {
         if (row.house == null) continue;
         const ms = Math.round(row.time.getNanoTime() / 1e6);
-        byHour[localHour(ms)].push(row.house);
+        const elpatronW = elpatronWByHourMs?.get(ms) ?? 0;
+        // When the element dominates the hour (a burn, or night top-ups over a small base), the
+        // residual is unmeasurable — drop the sample instead of feeding a fake 0 into the median
+        if (elpatronW > row.house * 0.9) continue;
+        byHour[localHour(ms)].push(row.house - elpatronW);
       }
       if (byHour.some(bucket => bucket.length >= 3)) {
         profile = byHour.map(bucket => {
@@ -52,7 +86,10 @@ export async function fetchConsumptionForecast(
           const sorted = [...bucket].sort((a, b) => a - b);
           return sorted[Math.floor(sorted.length / 2)];
         });
-        logLog("Learned consumption profile (W by local hour):", profile.map(w => Math.round(w)).join(","));
+        logLog(
+          `Learned consumption profile (W by local hour${subtractElpatron ? ", elpatron share removed" : ""}):`,
+          profile.map(w => Math.round(w)).join(",")
+        );
       }
     } catch (e) {
       errorLog("Failed to learn consumption profile from InfluxDB, using fallback", e);
@@ -65,6 +102,40 @@ export async function fetchConsumptionForecast(
     source: profile ? "influx" : "fallback",
     fetchedAtMs: Date.now(),
     profile: finalProfile,
+    elpatronSubtracted: !!subtractElpatron,
   };
   return cache;
+}
+
+/**
+ * Estimate the element's average watts for each historical hour from the tank sensor: energy in ≈
+ * tank_wh_per_degree × (temperature rise + what standing loss ate). Hot-water usage hours show a
+ * steep temperature DROP and clamp to 0; hours holding the thermostat band land near the standing
+ * loss — both are what actually happened electrically, to within the calibration.
+ */
+async function estimateElpatronHistory(
+  influxClient: Influx.InfluxDB,
+  knobs: ElpatronHistoryKnobs,
+  withTimeout: <T>(promise: Promise<T>) => Promise<T>
+): Promise<Map<number, number>> {
+  const rows = (await withTimeout(
+    influxClient.query(
+      `SELECT mean(akkumulator) as tank FROM "frendebo_thermometers" WHERE time > now() - 14d GROUP BY time(1h)`
+    )
+  )) as unknown as { time: { getNanoTime(): number }; tank: number | null }[];
+  const hourMs = 3600 * 1000;
+  const tankByMs = new Map<number, number>();
+  for (const row of rows) {
+    if (row.tank == null) continue;
+    tankByMs.set(Math.round(row.time.getNanoTime() / 1e6), row.tank);
+  }
+  const elpatronWByMs = new Map<number, number>();
+  for (const [ms, tank] of tankByMs) {
+    const nextTank = tankByMs.get(ms + hourMs);
+    if (nextTank === undefined) continue;
+    const deltaDegrees = nextTank - tank;
+    const estimatedW = knobs.tank_wh_per_degree * (deltaDegrees + knobs.tank_cooling_degrees_per_hour);
+    elpatronWByMs.set(ms, Math.min(knobs.element_watts, Math.max(0, estimatedW)));
+  }
+  return elpatronWByMs;
 }

--- a/backend/src/autoTrading/elpatronForecast.ts
+++ b/backend/src/autoTrading/elpatronForecast.ts
@@ -1,0 +1,130 @@
+/**
+ * Expected water-heater ("elpatron") load for the planner. The element isn't statistically
+ * forecastable — WE switch it (elpatronSwitching.ts gates it by solar for the morning showers of
+ * airbnb guests, or someone turns the GPIO on by hand) — so instead of learning it from history,
+ * this simulates the controller's own switching rule plus a small tank thermal model forward:
+ * a ~6 kW burn from first light until the tank thermostat cuts at ~50 °C, then duty-cycled
+ * top-ups covering the standing loss while heating stays allowed.
+ *
+ * Applies only while the element is armed (solar switching enabled in this project, or the GPIO
+ * currently on). In stove season both are off and this contributes nothing — the pellet stove's
+ * tank heating must not be attributed to the element.
+ */
+
+import Influx from "influx";
+import { warnLog } from "../utilities/logging.ts";
+import { readElpatronGpioIsOn } from "../utilities/heatingPi.ts";
+import type { Config } from "../config/config.types.ts";
+
+export type ElpatronForecast = {
+  /** Expected element draw in watts at a given time; 0 whenever not armed */
+  wattsAt: (ms: number) => number;
+  armed: boolean;
+  tankTempC: number | undefined;
+};
+
+const UNARMED: Omit<ElpatronForecast, "armed"> = { wattsAt: () => 0, tankTempC: undefined };
+
+export async function fetchElpatronForecast({
+  elpatronConfig,
+  influxClient,
+  solarWattsAt,
+  nowMs,
+}: {
+  elpatronConfig: Config["elpatron_switching"];
+  influxClient: Influx.InfluxDB | undefined;
+  solarWattsAt: (ms: number) => number;
+  nowMs: number;
+}): Promise<ElpatronForecast> {
+  // Armed = we actively switch it by solar, or someone left the element GPIO on manually.
+  // The gpio read is skipped when switching is enabled — armed either way.
+  let armed = elpatronConfig.enabled;
+  if (!armed) {
+    armed = (await readElpatronGpioIsOn(elpatronConfig.heating_pi_ip)) === true;
+  }
+  if (!armed) return { ...UNARMED, armed: false };
+
+  const tankTempC = await fetchTankTemperature(influxClient);
+  // Without a tank reading, assume mid-band: still predicts a plausible dawn burn + top-ups
+  const startTempC = tankTempC ?? elpatronConfig.tank_max_temperature - 5;
+  const wattsAt = buildElpatronLoadModel({
+    nowMs,
+    startTempC,
+    // With switching disabled but the GPIO on, only the tank thermostat limits the element
+    heatingAllowedAt: elpatronConfig.enabled ? ms => solarWattsAt(ms) > elpatronConfig.min_solar_input : () => true,
+    element_watts: elpatronConfig.element_watts,
+    tank_wh_per_degree: elpatronConfig.tank_wh_per_degree,
+    tank_cooling_degrees_per_hour: elpatronConfig.tank_cooling_degrees_per_hour,
+    tank_max_temperature: elpatronConfig.tank_max_temperature,
+  });
+  return { wattsAt, armed: true, tankTempC };
+}
+
+/**
+ * Pure forward simulation of tank temperature vs the switching rule, 15-min steps over 3 days
+ * (past the planner's price horizon + constraint tail). Exported for the selftest.
+ */
+export function buildElpatronLoadModel({
+  nowMs,
+  startTempC,
+  heatingAllowedAt,
+  element_watts,
+  tank_wh_per_degree,
+  tank_cooling_degrees_per_hour,
+  tank_max_temperature,
+}: {
+  nowMs: number;
+  startTempC: number;
+  heatingAllowedAt: (ms: number) => boolean;
+  element_watts: number;
+  tank_wh_per_degree: number;
+  tank_cooling_degrees_per_hour: number;
+  tank_max_temperature: number;
+}): (ms: number) => number {
+  const stepMs = 15 * 60 * 1000;
+  const stepHours = 0.25;
+  const steps = 3 * 24 * 4;
+  const roomTempC = 20;
+  // While the thermostat holds the band, the element duty-cycles at just the standing loss
+  const standingLossW = tank_wh_per_degree * tank_cooling_degrees_per_hour;
+  const watts = new Array<number>(steps);
+  let tempC = startTempC;
+  for (let step = 0; step < steps; step++) {
+    const midMs = nowMs + step * stepMs + stepMs / 2;
+    if (heatingAllowedAt(midMs) && tempC < tank_max_temperature) {
+      watts[step] = element_watts;
+      tempC = Math.min(
+        tank_max_temperature,
+        tempC + ((element_watts - standingLossW) / tank_wh_per_degree) * stepHours
+      );
+    } else if (heatingAllowedAt(midMs)) {
+      watts[step] = standingLossW;
+    } else {
+      watts[step] = 0;
+      tempC = Math.max(roomTempC, tempC - tank_cooling_degrees_per_hour * stepHours);
+    }
+  }
+  return ms => {
+    const step = Math.floor((ms - nowMs) / stepMs);
+    return step >= 0 && step < steps ? watts[step] : 0;
+  };
+}
+
+async function fetchTankTemperature(influxClient: Influx.InfluxDB | undefined): Promise<number | undefined> {
+  if (!influxClient) return undefined;
+  try {
+    const rows = (await Promise.race([
+      influxClient.query(`SELECT last(akkumulator) as tank FROM "frendebo_thermometers" WHERE time > now() - 2h`),
+      new Promise((_, reject) => setTimeout(() => reject(new Error("tank temperature query timed out")), 15_000)),
+    ])) as unknown as { tank: number | null }[];
+    const tank = rows[0]?.tank;
+    if (tank == null) {
+      warnLog("Elpatron forecast: no recent tank temperature in InfluxDB — assuming mid-band");
+      return undefined;
+    }
+    return tank;
+  } catch (e) {
+    warnLog("Elpatron forecast: tank temperature query failed — assuming mid-band", e);
+    return undefined;
+  }
+}

--- a/backend/src/autoTrading/planPreview.ts
+++ b/backend/src/autoTrading/planPreview.ts
@@ -15,6 +15,7 @@ import type { Config } from "../config/config.types.ts";
 import { fetchPrices } from "./priceService.ts";
 import { fetchSolarForecast } from "./solarForecast.ts";
 import { fetchConsumptionForecast } from "./consumptionForecast.ts";
+import { fetchElpatronForecast } from "./elpatronForecast.ts";
 import { generatePlan } from "./planner.ts";
 import type { PlannerInput } from "./planner.types.ts";
 
@@ -49,7 +50,21 @@ const solar = await fetchSolarForecast(
   at.solar_model.watts_per_direct_radiation,
   at.solar_model.watts_per_diffuse_radiation
 );
-const consumption = await fetchConsumptionForecast(influxClient, at.fallback_house_load_watts);
+const elpatronConfig = { ...default_config.elpatron_switching, ...config.elpatron_switching };
+const elpatron = await fetchElpatronForecast({
+  elpatronConfig,
+  influxClient,
+  solarWattsAt: solar.wattsAt,
+  nowMs: Date.now(),
+});
+console.log(
+  `Elpatron: ${elpatron.armed ? `armed, tank ${elpatron.tankTempC ?? "?"}°C — modeled as known load` : "not armed"}\n`
+);
+const consumption = await fetchConsumptionForecast(
+  influxClient,
+  at.fallback_house_load_watts,
+  elpatron.armed ? elpatronConfig : undefined
+);
 
 const fixedSells = Object.entries(config.scheduled_power_selling.schedule)
   .map(([start, e]) => ({ startMs: +new Date(start), endMs: +new Date(e.end_time), watts: Number(e.power_watts) }))
@@ -62,7 +77,7 @@ const input: PlannerInput = {
   nowMs: Date.now(),
   prices: prices.slots,
   solarWattsAt: solar.wattsAt,
-  houseLoadWattsAt: consumption.wattsAt,
+  houseLoadWattsAt: ms => consumption.wattsAt(ms) + elpatron.wattsAt(ms),
   parasiticWatts: config.soc_calculations.current_state.parasitic_consumption,
   socPercent: soc,
   capacityWh: config.soc_calculations.current_state.capacity,

--- a/backend/src/autoTrading/planner.selftest.ts
+++ b/backend/src/autoTrading/planner.selftest.ts
@@ -5,6 +5,7 @@
 import { generatePlan, projectWithFixedWindows, SLOT_MS } from "./planner.ts";
 import { fitSolarModel, fitIsPlausibleVsCurrent } from "./solarCalibration.ts";
 import { computeRealizedRevenue } from "./tradingPerformance.ts";
+import { buildElpatronLoadModel } from "./elpatronForecast.ts";
 import type { PlannerInput } from "./planner.types.ts";
 
 const H = 3600_000;
@@ -563,6 +564,45 @@ function check(name: string, cond: boolean, detail = "") {
     "  sells:",
     plan.sells.map(w => `h${(w.startMs - t0) / H}-h${(w.endMs - t0) / H}@${w.avgSpot.toFixed(2)}`).join(", ")
   );
+}
+
+// ---------- Scenario 13: elpatron load model — dawn burn, thermostat top-ups, off at night ----------
+// The water heater is our own switched load (solar-gated for airbnb-guest morning showers):
+// the model must predict the ~6 kW recovery burn at first light, decay to standing-loss top-ups
+// once the tank thermostat band is reached, and nothing outside heating-allowed hours.
+{
+  const elpatronKnobs = {
+    element_watts: 6200,
+    tank_wh_per_degree: 480,
+    tank_cooling_degrees_per_hour: 1,
+    tank_max_temperature: 50,
+  };
+  // Solar-gated: heating allowed h1..h15 (first light to sunset), tank cooled to 37°C overnight
+  const gated = buildElpatronLoadModel({
+    nowMs: t0,
+    startTempC: 37,
+    heatingAllowedAt: ms => (ms - t0) / H >= 1 && (ms - t0) / H <= 15,
+    ...elpatronKnobs,
+  });
+  check("elpatron: no draw before first light", gated(t0 + 0.5 * H) === 0);
+  check("elpatron: full burn at first light", gated(t0 + 1.5 * H) === 6200, `(${gated(t0 + 1.5 * H)} W)`);
+  check("elpatron: thermostat reached → standing-loss top-ups", gated(t0 + 4 * H) === 480, `(${gated(t0 + 4 * H)} W)`);
+  check("elpatron: off after sunset", gated(t0 + 16 * H) === 0);
+  let dayKwh = 0;
+  for (let ms = t0; ms < t0 + 24 * H; ms += SLOT_MS) dayKwh += (gated(ms) * 0.25) / 1000;
+  check(
+    "elpatron: daily energy in the observed 8-16 kWh band",
+    dayKwh > 8 && dayKwh < 16,
+    `(${dayKwh.toFixed(1)} kWh)`
+  );
+  // GPIO on without solar switching: only the thermostat limits it — top-ups continue at night
+  const ungated = buildElpatronLoadModel({
+    nowMs: t0,
+    startTempC: 50,
+    heatingAllowedAt: () => true,
+    ...elpatronKnobs,
+  });
+  check("elpatron: manual-on holds the band around the clock", ungated(t0 + 20 * H) === 480);
 }
 
 console.log(fails.length ? `\n${fails.length} FAILURES: ${fails.join(", ")}` : "\nAll scenarios passed");

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -74,6 +74,11 @@ export const default_config: Config = {
   elpatron_switching: {
     enabled: false,
     min_solar_input: 6000,
+    heating_pi_ip: "192.168.1.100",
+    element_watts: 6200,
+    tank_wh_per_degree: 480,
+    tank_cooling_degrees_per_hour: 1,
+    tank_max_temperature: 50,
   },
   soc_calculations: {
     recalculate_parameters_interval_seconds: 1800,
@@ -129,15 +134,17 @@ export const default_config: Config = {
 };
 
 /**
- * Top-level keys merge shallowly, but automatic_trading merges one level deeper: planner knobs get
- * added over time, and a config.json written before a knob existed must still pick up its default
- * (the planner does raw arithmetic on these — a missing knob would silently NaN every projection).
+ * Top-level keys merge shallowly, but automatic_trading and elpatron_switching merge one level
+ * deeper: knobs get added over time, and a config.json written before a knob existed must still
+ * pick up its default (the planner and the elpatron load model do raw arithmetic on these — a
+ * missing knob would silently NaN projections).
  */
 function mergeWithDefaults(partial: Partial<Config>): Config {
   return {
     ...default_config,
     ...partial,
     automatic_trading: { ...default_config.automatic_trading, ...partial.automatic_trading },
+    elpatron_switching: { ...default_config.elpatron_switching, ...partial.elpatron_switching },
   };
 }
 

--- a/backend/src/config/config.types.ts
+++ b/backend/src/config/config.types.ts
@@ -142,8 +142,23 @@ export type Config = {
     };
   };
   elpatron_switching: {
+    /** Let this controller gate the water heater element by solar (write-gpio to the heating pi) */
     enabled: boolean;
+    /** Solar watts above which the element is allowed on */
     min_solar_input: number;
+    /** The pi running github.com/danieltroger/heating (ws server on :9321 owns the element GPIO) */
+    heating_pi_ip: string;
+    /** Measured element draw when on: ~2.05 kW × 3 phases (2026-07 measurement, ~7 kW nameplate) */
+    element_watts: number;
+    /**
+     * Effective heat capacity at the tank sensor (Wh per °C) — calibrated from a 2026-07-10 burn:
+     * 6.2 kW × 0.7 h moved the sensor +9.1 °C. Used to predict burn length and standing losses.
+     */
+    tank_wh_per_degree: number;
+    /** Observed tank cooling rate with the element off (standing loss, °C per hour) */
+    tank_cooling_degrees_per_hour: number;
+    /** The tank thermostat cuts the element around this temperature (kept low — the room warms up) */
+    tank_max_temperature: number;
   };
   stop_charging_below_current: number;
   full_battery_voltage: number;

--- a/backend/src/elpatronSwitching.ts
+++ b/backend/src/elpatronSwitching.ts
@@ -1,26 +1,24 @@
 import { type Accessor, createEffect, createMemo, createResource } from "solid-js";
-import { WebSocket } from "ws";
-import { DepictAPIWS, random_string, wait } from "./vendor/depictUtilishared.ts";
+import { random_string, wait } from "./vendor/depictUtilishared.ts";
 import { useTotalSolarPower } from "./utilities/useTotalSolarPower.ts";
 import { useFromMqttProvider } from "./mqttValues/MQTTValuesProvider.ts";
 import { reactiveBatteryVoltage } from "./mqttValues/mqttHelpers.ts";
+import { getHeatingPiSocket } from "./utilities/heatingPi.ts";
 import type { Config } from "./config/config.types.ts";
 
-// @ts-ignore
-globalThis.WebSocket = WebSocket;
-
-let socket: DepictAPIWS | undefined;
 let lastSwitch = 0;
 
 export function elpatronSwitching(config: Accessor<Config>) {
   const { mqttValues } = useFromMqttProvider();
   const functionalityEnabled = createMemo(() => config().elpatron_switching.enabled);
+  // Memo so the effect doesn't rebuild (and re-send gpio writes) on unrelated config writes
+  const heatingPiIp = createMemo(() => config().elpatron_switching.heating_pi_ip);
   const fromSolar = createMemo(() => useTotalSolarPower());
   const getPowerDirection = () => mqttValues.line_power_direction?.value;
 
   createEffect(() => {
     if (!functionalityEnabled()) return;
-    socket ||= new DepictAPIWS("ws://192.168.1.100:9321");
+    const socket = getHeatingPiSocket(heatingPiIp());
     const elpatronShouldBeEnabled = createMemo<boolean | undefined>(() => {
       const solar = fromSolar();
       const powerDirection = getPowerDirection();

--- a/backend/src/utilities/heatingPi.ts
+++ b/backend/src/utilities/heatingPi.ts
@@ -1,0 +1,60 @@
+/**
+ * Client for the heating pi (github.com/danieltroger/heating): a ws server on :9321 that owns the
+ * boiler-room GPIOs, among them the water heater element ("elpatron"). Shared by the solar-based
+ * element switching and the auto-trader's elpatron load forecast so both use one connection.
+ */
+
+import { WebSocket } from "ws";
+import { DepictAPIWS, random_string } from "../vendor/depictUtilishared.ts";
+import { warnLog } from "./logging.ts";
+
+// DepictAPIWS expects a browser-style global WebSocket
+// @ts-ignore
+globalThis.WebSocket = WebSocket;
+
+const sockets = new Map<string, DepictAPIWS>();
+
+export function getHeatingPiSocket(heatingPiIp: string): DepictAPIWS {
+  let socket = sockets.get(heatingPiIp);
+  if (!socket) {
+    socket = new DepictAPIWS(`ws://${heatingPiIp}:9321`);
+    sockets.set(heatingPiIp, socket);
+  }
+  return socket;
+}
+
+let gpioReadCache: { heatingPiIp: string; atMs: number; value: boolean | undefined } | undefined;
+
+/**
+ * Whether the element GPIO is currently on (the pin is active-low: raw 0 = element powered).
+ * Returns undefined when the heating pi doesn't answer in time — ensure_sent retries forever, and
+ * a plan run must not hang on an unreachable pi in another building. Results (including failures)
+ * are cached for 10 minutes so the guard's 15-min ticks don't hammer or stall on the pi.
+ */
+export async function readElpatronGpioIsOn(heatingPiIp: string): Promise<boolean | undefined> {
+  if (gpioReadCache && gpioReadCache.heatingPiIp === heatingPiIp && Date.now() - gpioReadCache.atMs < 10 * 60_000) {
+    return gpioReadCache.value;
+  }
+  const value = await readElpatronGpioUncached(heatingPiIp);
+  gpioReadCache = { heatingPiIp, atMs: Date.now(), value };
+  return value;
+}
+
+async function readElpatronGpioUncached(heatingPiIp: string): Promise<boolean | undefined> {
+  const socket = getHeatingPiSocket(heatingPiIp);
+  const request = socket.ensure_sent({ id: random_string(), command: "read", key: "gpio" }) as Promise<
+    [{ status: string; value?: { outputs?: Record<string, number> } }, unknown]
+  >;
+  const timeout = new Promise<undefined>(resolve => setTimeout(() => resolve(undefined), 5000));
+  const result = await Promise.race([request.then(([response]) => response), timeout]);
+  if (!result || result.status !== "ok") {
+    warnLog("Heating pi: gpio read failed or timed out", heatingPiIp, result);
+    return undefined;
+  }
+  const rawState = result.value?.outputs?.electric_heating_element;
+  if (rawState === undefined) {
+    warnLog("Heating pi: gpio response has no electric_heating_element output", result.value);
+    return undefined;
+  }
+  return rawState === 0;
+}


### PR DESCRIPTION
The elpatron is our own scheduled load (solar-gated by `elpatronSwitching` for the airbnb guests' morning showers, or manually via GPIO) — measured at **~6.2 kW across all three phases**, ~8–14 kWh/day, which matches the +9…+14 kWh/day house-forecast error in the settlements almost exactly. A 14-day hourly median cannot learn a bimodal load; this stops trying.

## What it does

- **`elpatronForecast.ts`** — simulates our own switching rule forward with a tank thermal model: live `akkumulator` temp from InfluxDB, `tank_wh_per_degree` (calibrated 480 from the 2026-07-10 burn: 6.2 kW × 0.7 h ≈ +9.1 °C at the sensor), ~1 °C/h standing loss, thermostat cutoff 50 °C. Predicts the dawn burn until the thermostat cuts, then standing-loss top-ups while heating is allowed.
- **Armed gating** (per the requirement): applies only when `elpatron_switching.enabled` OR the element GPIO reads on (active-low 0 = on) via the heating pi's ws API — in pellet-stove season both are off and nothing changes, so stove-driven tank warming is never misattributed.
- **`consumptionForecast.ts`** — when armed, strips the element share from each historical hour via tank energy balance (`C × (ΔT + cooling)`), dropping hours the element dominated instead of feeding fake zeros into the median. The planner adds the modeled element back as a forward load — no double counting.
- **Plumbing**: shared heating-pi ws client with 5 s timeout + 10 min cache (a plan/guard tick must never hang on an unreachable pi in another building); `heating_pi_ip` moved from hardcoded to config (the live config already had the key); `elpatron_switching` defaults deep-merge like `automatic_trading`.

## Validation

- Selftest: 6 new checks on the pure model (dawn burn, top-ups, off outside allowed hours, manual-on holds the band 24/7, daily energy lands in the observed 8–16 kWh band) — all 19 scenarios green, typecheck clean.
- Live read-only `planPreview` (23:25 local, battery empty, tank 41.7 °C): reports "armed, modeled as known load", the relearned baseline is a believable household profile (night 230–630 W, evening peak ~1.8 kW — no more elpatron smear), and the projection now *sees* tomorrow's dawn burn — it immediately began evaluating cheap night pre-buying to cover it instead of being surprised at 05:00.

Deliberately not done (per discussion): moving the heating into midday (dad vetoes the room warming up), quantile/intraday-scaling hardening, anything fancier than the 200 W trigger — guests leave next week.

Merge order note: this is written off `main` and should merge before the `ah-soc-ledger` testing branch, which will be rebased on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gnx4sUB71SzTnG5iP5dcZN