### PR TITLE
Alerting: P1/P2/P3 Pushover pushes with threshold rules, errorLog forwarding and burn-in dry-run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ backend/for_influx.txt
 
 auto_trader_state.json
 backend/auto_trader_state.json
+alert_state.json
+backend/alert_state.json

--- a/backend/src/alerting/alertManager.ts
+++ b/backend/src/alerting/alertManager.ts
@@ -1,0 +1,180 @@
+import { readFileSync, promises as fs_promises } from "fs";
+import path from "path";
+import process from "process";
+import { type Accessor, createSignal, untrack } from "solid-js";
+import type { Config } from "../config/config.types.ts";
+import type { AlertRecord, AlertSeverity } from "./alerting.types.ts";
+import { decideSend, errorLogDedupeKey, formatErrorLogMessage, severityToPushoverPriority } from "./alertingLogic.ts";
+import { sendPushoverMessage } from "./pushoverTransport.ts";
+import { debugLog, logLog, setOnErrorLog, warnLog } from "../utilities/logging.ts";
+
+export type AlertManager = {
+  /** Fire an alert. Resolves once delivery has been decided/attempted (rules fire-and-forget this). */
+  raise: (alert: { key: string; severity: AlertSeverity; title: string; message: string }) => Promise<AlertRecord>;
+  /** Newest first, capped — exposed over the ws for the /system alerts card. */
+  recentAlerts: Accessor<AlertRecord[]>;
+};
+
+type PersistedAlertState = {
+  last_sent: Record<string, { at: string; severity: AlertSeverity }>;
+  recent: AlertRecord[];
+};
+
+const RECENT_CAP = 50;
+
+/**
+ * The manager survives a main() crash-restart (its state is module-external: fs + these signals),
+ * so the crash handler in index.ts can alert through the previous instance while the next one boots.
+ */
+let activeManager: AlertManager | undefined;
+const earlyAlerts: Parameters<AlertManager["raise"]>[0][] = [];
+const mainCrashTimesMs: number[] = [];
+
+export function createAlertManager(config: Accessor<Config>): AlertManager {
+  const persisted = loadAlertState();
+  const [recentAlerts, setRecentAlerts] = createSignal<AlertRecord[]>(persisted.recent);
+  const lastSentByKey = new Map<string, { atMs: number; severity: AlertSeverity }>(
+    Object.entries(persisted.last_sent).map(([key, entry]) => [
+      key,
+      { atMs: +new Date(entry.at), severity: entry.severity },
+    ])
+  );
+  const pushedAtMs: number[] = [];
+  let persistTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const persist = () => {
+    clearTimeout(persistTimer);
+    persistTimer = setTimeout(() => {
+      const snapshot: PersistedAlertState = {
+        last_sent: Object.fromEntries(
+          [...lastSentByKey].map(([key, entry]) => [
+            key,
+            { at: new Date(entry.atMs).toISOString(), severity: entry.severity },
+          ])
+        ),
+        recent: untrack(recentAlerts),
+      };
+      fs_promises
+        .writeFile(alertStateFilePath(), JSON.stringify(snapshot, null, 2), { encoding: "utf-8" })
+        .catch(e => warnLog("Alerting: failed to persist alert state", e));
+    }, 2000);
+  };
+
+  const raise: AlertManager["raise"] = async alert => {
+    const alertingConfig = untrack(config).alerting;
+    const nowMs = Date.now();
+    const record: AlertRecord = {
+      key: alert.key,
+      severity: alert.severity,
+      title: alertingConfig.site_name ? `[${alertingConfig.site_name}] ${alert.title}` : alert.title,
+      message: alert.message,
+      at: new Date(nowMs).toISOString(),
+      delivery: "disabled",
+    };
+
+    if (!alertingConfig.enabled) {
+      debugLog("Alerting disabled — swallowing", alert.key);
+      return record;
+    }
+
+    while (pushedAtMs.length && pushedAtMs[0] < nowMs - 3600_000) pushedAtMs.shift();
+    const decision = decideSend({
+      nowMs,
+      severity: alert.severity,
+      lastSentForKey: lastSentByKey.get(alert.key),
+      cooldownMs: alertingConfig.cooldown_minutes * 60_000,
+      pushedAtMsLastHour: pushedAtMs,
+      maxPushesPerHour: alertingConfig.max_pushes_per_hour,
+    });
+
+    if (decision === "cooldown") {
+      // A repeat inside the cooldown isn't news — log it, don't clutter the recent list
+      debugLog(`Alerting: ${alert.key} still in cooldown, not re-sending`);
+      record.delivery = "cooldown";
+      return record;
+    }
+
+    if (decision === "rate_capped") {
+      record.delivery = "rate_capped";
+      warnLog(`Alerting: hourly push cap reached — suppressing ${alert.key}`);
+    } else if (alertingConfig.dry_run) {
+      record.delivery = "dry_run";
+      logLog(`Alerting DRY RUN [${alert.severity}] ${record.title}: ${record.message}`);
+    } else if (!alertingConfig.pushover_app_token || !alertingConfig.pushover_recipient_key) {
+      record.delivery = "unconfigured";
+      warnLog(`Alerting: pushover tokens not configured — can't send [${alert.severity}] ${record.title}`);
+    } else {
+      const result = await sendPushoverMessage({
+        token: alertingConfig.pushover_app_token,
+        user: alertingConfig.pushover_recipient_key,
+        title: record.title,
+        message: record.message,
+        ...severityToPushoverPriority(alert.severity),
+      });
+      record.delivery = result.ok ? "pushed" : "push_failed";
+      record.detail = result.detail;
+    }
+
+    if (record.delivery === "pushed" || record.delivery === "dry_run") {
+      lastSentByKey.set(alert.key, { atMs: nowMs, severity: alert.severity });
+      if (record.delivery === "pushed") pushedAtMs.push(nowMs);
+    }
+    setRecentAlerts(existing => [record, ...existing].slice(0, RECENT_CAP));
+    persist();
+    return record;
+  };
+
+  const manager: AlertManager = { raise, recentAlerts };
+  activeManager = manager;
+
+  // Every errorLog() anywhere in the backend becomes a deduped P2 (the "general error" tier)
+  setOnErrorLog(args => {
+    if (!untrack(config).alerting.error_log_p2) return;
+    void raise({
+      key: errorLogDedupeKey(args),
+      severity: "P2",
+      title: "Error logged",
+      message: formatErrorLogMessage(args),
+    });
+  });
+
+  for (const early of earlyAlerts.splice(0)) void raise(early);
+  return manager;
+}
+
+/**
+ * Called from the main() crash-restart loop in index.ts — deliberately importable without a
+ * manager existing yet (a crash during boot queues the alert until the next boot creates one).
+ * Two crashes within 30 minutes escalate to P1: single crashes recover silently all the time,
+ * a loop means the controller is effectively down.
+ */
+export function alertOnMainCrash(error: unknown) {
+  const nowMs = Date.now();
+  mainCrashTimesMs.push(nowMs);
+  while (mainCrashTimesMs.length && mainCrashTimesMs[0] < nowMs - 30 * 60_000) mainCrashTimesMs.shift();
+  const alert = {
+    key: "main-crash",
+    severity: (mainCrashTimesMs.length >= 2 ? "P1" : "P2") as AlertSeverity,
+    title: mainCrashTimesMs.length >= 2 ? "Controller crash-looping" : "Controller crashed (restarting)",
+    message: `${mainCrashTimesMs.length} crash(es) in 30 min. Latest: ${formatErrorLogMessage([error])}`,
+  };
+  if (activeManager) void activeManager.raise(alert);
+  else if (earlyAlerts.length < 20) earlyAlerts.push(alert);
+}
+
+function loadAlertState(): PersistedAlertState {
+  try {
+    // Synchronous on purpose: raise() must be usable the moment the manager exists, and a read
+    // of a tiny json at boot is cheaper than making every caller await manager readiness.
+    return { last_sent: {}, recent: [], ...JSON.parse(readFileSync(alertStateFilePath(), { encoding: "utf-8" })) };
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException)?.code !== "ENOENT") {
+      warnLog("Alerting: failed to load alert state — starting fresh (cooldowns reset)", e);
+    }
+    return { last_sent: {}, recent: [] };
+  }
+}
+
+function alertStateFilePath() {
+  return path.dirname(process.argv[1]) + "/../alert_state.json";
+}

--- a/backend/src/alerting/alertManager.ts
+++ b/backend/src/alerting/alertManager.ts
@@ -40,6 +40,9 @@ export function createAlertManager(config: Accessor<Config>): AlertManager {
     ])
   );
   const pushedAtMs: number[] = [];
+  // Forwarded errorLogs are unbounded and uncurated compared to the threshold rules, so they get
+  // their own (smaller) hourly budget — log noise must never rate-cap a real hazard P2.
+  const errorLogPushedAtMs: number[] = [];
   let persistTimer: ReturnType<typeof setTimeout> | undefined;
 
   const persist = () => {
@@ -77,14 +80,18 @@ export function createAlertManager(config: Accessor<Config>): AlertManager {
       return record;
     }
 
-    while (pushedAtMs.length && pushedAtMs[0] < nowMs - 3600_000) pushedAtMs.shift();
+    const isForwardedErrorLog = alert.key.startsWith("errorlog:");
+    const budgetBucket = isForwardedErrorLog ? errorLogPushedAtMs : pushedAtMs;
+    while (budgetBucket.length && budgetBucket[0] < nowMs - 3600_000) budgetBucket.shift();
     const decision = decideSend({
       nowMs,
       severity: alert.severity,
       lastSentForKey: lastSentByKey.get(alert.key),
       cooldownMs: alertingConfig.cooldown_minutes * 60_000,
-      pushedAtMsLastHour: pushedAtMs,
-      maxPushesPerHour: alertingConfig.max_pushes_per_hour,
+      pushedAtMsLastHour: budgetBucket,
+      maxPushesPerHour: isForwardedErrorLog
+        ? alertingConfig.max_errorlog_pushes_per_hour
+        : alertingConfig.max_pushes_per_hour,
     });
 
     if (decision === "cooldown") {
@@ -117,7 +124,7 @@ export function createAlertManager(config: Accessor<Config>): AlertManager {
 
     if (record.delivery === "pushed" || record.delivery === "dry_run") {
       lastSentByKey.set(alert.key, { atMs: nowMs, severity: alert.severity });
-      if (record.delivery === "pushed") pushedAtMs.push(nowMs);
+      if (record.delivery === "pushed") budgetBucket.push(nowMs);
     }
     setRecentAlerts(existing => [record, ...existing].slice(0, RECENT_CAP));
     persist();

--- a/backend/src/alerting/alertRules.ts
+++ b/backend/src/alerting/alertRules.ts
@@ -90,6 +90,28 @@ export function startAlertRules(ctx: {
     );
   });
 
+  // ——— cooling outlet air: the early ventilation alarm (see cooling_outlet_temp_p2_celsius docs) ———
+  const coolingOutletProbes = createMemo(() =>
+    Object.values(ctx.temperatures())
+      .map(reading => reading())
+      .filter(
+        (reading): reading is NonNullable<typeof reading> => !!reading && reading.label.startsWith("cooling_outlet")
+      )
+  );
+  const ventilationAlert = edgeAlert("ventilation", "P2", { resolveNotice: true });
+  createEffect(() => {
+    const probes = coolingOutletProbes();
+    if (!probes.length) return;
+    const hottest = probes.reduce((a, b) => (a.value >= b.value ? a : b));
+    const threshold = alerting().cooling_outlet_temp_p2_celsius;
+    ventilationAlert.update(
+      thresholdState(hottest.value, threshold, threshold - 3),
+      "Inverter room getting hot",
+      () =>
+        `${hottest.label} at ${round1(hottest.value)}°C (P2 threshold ${threshold}°C, normal peak ~34°C) — check the door/ventilation before it reaches the 100°C cutoff`
+    );
+  });
+
   // ——— battery voltage window (16s LiFePO4: cells tolerate down to 2.5 V/cell = 40 V) ———
   const undervoltAlert = edgeAlert("battery-undervoltage", "P2", { resolveNotice: true });
   const overvoltAlert = edgeAlert("battery-overvoltage", "P1", { resolveNotice: true });

--- a/backend/src/alerting/alertRules.ts
+++ b/backend/src/alerting/alertRules.ts
@@ -1,0 +1,229 @@
+import { type Accessor, createEffect, createMemo, onCleanup, untrack } from "solid-js";
+import type { Config } from "../config/config.types.ts";
+import type { CurrentBatteryPowerBroadcast } from "../sharedTypes.ts";
+import { mqttValueKeys } from "../sharedTypes.ts";
+import type { useFromMqttProvider } from "../mqttValues/MQTTValuesProvider.ts";
+import type { useTemperatures } from "../temperatureMeasuring/useTemperatures.ts";
+import type { AutoTraderStatus } from "../autoTrading/autoTraderState.types.ts";
+import type { AlertManager } from "./alertManager.ts";
+import type { AlertSeverity } from "./alerting.types.ts";
+import { formatSekForAlert, round1, thresholdState } from "./alertingLogic.ts";
+
+/**
+ * The watchers: each rule reads signals that already drive the rest of the controller and turns
+ * threshold crossings into alerts. Rules own their hysteresis (set/clear gap via thresholdState)
+ * so a value hovering at a threshold can't machine-gun pushes; the manager adds per-key cooldown
+ * and rate caps on top.
+ *
+ * Deliberately NOT here: plan failures and other instrumented errors — every errorLog() in the
+ * backend is already forwarded as a P2 by the manager, so those come for free.
+ */
+export function startAlertRules(ctx: {
+  config: Accessor<Config>;
+  manager: AlertManager;
+  temperatures: ReturnType<typeof useTemperatures>;
+  mqttValues: ReturnType<typeof useFromMqttProvider>["mqttValues"];
+  averageSOC: Accessor<number | undefined>;
+  currentBatteryPower: Accessor<CurrentBatteryPowerBroadcast | undefined>;
+  autoTraderStatus: Accessor<AutoTraderStatus | undefined>;
+}) {
+  const bootedAtMs = Date.now();
+  const alerting = createMemo(() => ctx.config().alerting);
+  const inGracePeriod = () => Date.now() - bootedAtMs < untrack(alerting).startup_grace_seconds * 1000;
+
+  /**
+   * Rising edge fires the alert, falling edge (past the clear point) optionally sends a quiet P3
+   * resolution. `next === undefined` means "inside the hysteresis gap — hold the current state".
+   */
+  const edgeAlert = (key: string, severity: AlertSeverity, options?: { resolveNotice?: boolean }) => {
+    let active = false;
+    return {
+      update(next: boolean | undefined, title: string, message: () => string) {
+        if (next === undefined || next === active) return;
+        active = next;
+        if (next) {
+          void ctx.manager.raise({ key, severity, title, message: message() });
+        } else if (options?.resolveNotice) {
+          void ctx.manager.raise({
+            key: `${key}:resolved`,
+            severity: "P3",
+            title: `Resolved: ${title}`,
+            message: message(),
+          });
+        }
+      },
+    };
+  };
+
+  // ——— battery probe temperature (cells + bus bars; cooling_* probes sit on the inverter air path) ———
+  const batteryProbes = createMemo(() =>
+    Object.values(ctx.temperatures())
+      .map(reading => reading())
+      .filter(
+        (reading): reading is NonNullable<typeof reading> =>
+          !!reading && (reading.label.startsWith("cell") || reading.label.includes("bus_bar"))
+      )
+  );
+  const batteryTempAlert = edgeAlert("battery-temp", "P1", { resolveNotice: true });
+  createEffect(() => {
+    const probes = batteryProbes();
+    if (!probes.length) return;
+    const hottest = probes.reduce((a, b) => (a.value >= b.value ? a : b));
+    const threshold = alerting().battery_temp_p1_celsius;
+    batteryTempAlert.update(
+      thresholdState(hottest.value, threshold, threshold - 3),
+      "Battery temperature high",
+      () => `${hottest.label} at ${round1(hottest.value)}°C (P1 threshold ${threshold}°C)`
+    );
+  });
+
+  // ——— inverter temperature (hard shutdown at 100 °C — the 97 °C threshold sits deliberately close) ———
+  const inverterTempAlert = edgeAlert("inverter-temp", "P1", { resolveNotice: true });
+  createEffect(() => {
+    const reading = ctx.mqttValues.component_max_temperature;
+    if (!reading) return;
+    const threshold = alerting().inverter_temp_p1_celsius;
+    inverterTempAlert.update(
+      thresholdState(reading.value, threshold, threshold - 5),
+      "Inverter near thermal shutdown",
+      () => `component_max_temperature ${round1(reading.value)}°C — the inverter shuts off at 100°C`
+    );
+  });
+
+  // ——— battery voltage window (16s LiFePO4: cells tolerate down to 2.5 V/cell = 40 V) ———
+  const undervoltAlert = edgeAlert("battery-undervoltage", "P2", { resolveNotice: true });
+  const overvoltAlert = edgeAlert("battery-overvoltage", "P1", { resolveNotice: true });
+  createEffect(() => {
+    const reading = ctx.mqttValues.battery_voltage;
+    if (!reading) return;
+    const limits = alerting();
+    const low = limits.battery_undervoltage_p2_volts;
+    const high = limits.battery_overvoltage_p1_volts;
+    undervoltAlert.update(
+      thresholdState(-reading.value, -low, -(low + 1)),
+      "Battery voltage low",
+      () => `${reading.value} V (P2 below ${low} V)`
+    );
+    overvoltAlert.update(
+      thresholdState(reading.value, high, high - 0.4),
+      "Battery voltage HIGH",
+      () => `${reading.value} V (P1 above ${high} V) — check the charge cutoff`
+    );
+  });
+
+  // ——— charging while frozen (LiFePO4 must not charge below ~0 °C) ———
+  const chargingFrozenAlert = edgeAlert("charging-below-freezing", "P1");
+  createEffect(() => {
+    const probes = batteryProbes();
+    const power = ctx.currentBatteryPower();
+    if (!probes.length || !power) return;
+    const coldest = probes.reduce((a, b) => (a.value <= b.value ? a : b));
+    const limit = alerting().charging_battery_temp_p1_celsius;
+    chargingFrozenAlert.update(
+      power.value > 200 && coldest.value <= limit
+        ? true
+        : power.value < 100 || coldest.value > limit + 1
+          ? false
+          : undefined,
+      "Charging a freezing battery",
+      () => `Charging at ${Math.round(power.value)} W with ${coldest.label} at ${round1(coldest.value)}°C`
+    );
+  });
+
+  // ——— SOC below the emergency floor while discharging (the guard should have prevented this) ———
+  const socFloorAlert = edgeAlert("soc-floor-breach", "P2", { resolveNotice: true });
+  createEffect(() => {
+    const soc = ctx.averageSOC();
+    const power = ctx.currentBatteryPower();
+    const floor = ctx.config().automatic_trading?.emergency_soc_floor_percent;
+    if (soc === undefined || !power || floor === undefined) return;
+    socFloorAlert.update(
+      soc < floor && power.value < -100 ? true : soc > floor + 3 || power.value > 100 ? false : undefined,
+      "SOC below emergency floor",
+      () => `averageSOC ${round1(soc)}% vs floor ${floor}% (battery ${Math.round(power.value)} W)`
+    );
+  });
+
+  // ——— staleness + grid presence: time-based, so polled rather than reactive ———
+  const staleMqttAlert = edgeAlert("mqtt-stale", "P2", { resolveNotice: true });
+  const staleTemperaturesAlert = edgeAlert("temperatures-stale", "P2", { resolveNotice: true });
+  const gridOutAlert = edgeAlert("grid-out", "P2", { resolveNotice: true });
+  let gridLowSinceMs: number | undefined;
+  const pollTimer = setInterval(() => {
+    if (inGracePeriod()) return;
+    const nowMs = Date.now();
+    const limits = untrack(alerting);
+
+    const newestMqttMs = Math.max(0, ...mqttValueKeys.map(key => untrack(() => ctx.mqttValues[key])?.time ?? 0));
+    staleMqttAlert.update(
+      newestMqttMs === 0 ? undefined : nowMs - newestMqttMs > limits.stale_mqtt_p2_minutes * 60_000,
+      "Inverter data stale",
+      () => `No mqtt updates for ${Math.round((nowMs - newestMqttMs) / 60_000)} min — USB reading daemon dead?`
+    );
+
+    const readings = untrack(() => Object.values(ctx.temperatures()).map(reading => reading()));
+    const newestTempMs = Math.max(0, ...readings.map(reading => reading?.time ?? 0));
+    staleTemperaturesAlert.update(
+      newestTempMs === 0 ? undefined : nowMs - newestTempMs > limits.stale_temperatures_p2_minutes * 60_000,
+      "Thermometers silent",
+      () => `No temperature updates for ${Math.round((nowMs - newestTempMs) / 60_000)} min`
+    );
+
+    const gridVoltage = untrack(() => ctx.mqttValues.ac_input_voltage_r);
+    const gridFresh = gridVoltage && nowMs - gridVoltage.time < 2 * 60_000;
+    const gridLow = !!gridFresh && gridVoltage.value < limits.grid_out_below_volts;
+    if (!gridLow) gridLowSinceMs = undefined;
+    else gridLowSinceMs ??= nowMs;
+    gridOutAlert.update(
+      // stale grid reading → hold (the mqtt-stale rule owns that failure)
+      !gridFresh ? undefined : gridLow && nowMs - gridLowSinceMs! >= limits.grid_out_p2_seconds * 1000,
+      "Grid appears down",
+      () =>
+        `ac_input_voltage_r at ${gridVoltage?.value ?? "?"} V for ${Math.round((nowMs - (gridLowSinceMs ?? nowMs)) / 1000)} s — house is running on the battery`
+    );
+  }, 15_000);
+  onCleanup(() => clearInterval(pollTimer));
+
+  // ——— trader guard interventions + P3 digests (watched via the status signal — autoTrader.ts untouched) ———
+  let previousGuardAction: string | undefined;
+  createEffect(() => {
+    const action = ctx.autoTraderStatus()?.guard?.last_action;
+    const previous = previousGuardAction;
+    previousGuardAction = action;
+    // previous === undefined covers boot: the persisted last_action must not re-alert on restart
+    if (action === undefined || previous === undefined || action === previous) return;
+    if (action.startsWith("ok") || action.startsWith("nothing")) return;
+    void ctx.manager.raise({ key: "trader-guard", severity: "P2", title: "Trading guard intervened", message: action });
+  });
+
+  let previousPlanGeneratedAt: string | undefined;
+  createEffect(() => {
+    const plan = ctx.autoTraderStatus()?.last_plan;
+    const previous = previousPlanGeneratedAt;
+    previousPlanGeneratedAt = plan?.generated_at;
+    if (!plan || previous === undefined || plan.generated_at === previous) return;
+    if (plan.trigger !== "daily" || !untrack(alerting).digest_p3) return;
+    const projection = plan.projection;
+    void ctx.manager.raise({
+      key: "daily-plan-digest",
+      severity: "P3",
+      title: "Today's trading plan",
+      message: `${plan.windows.length} window(s), sell ~${round1(projection.plannedSellKwh)} kWh, est ${formatSekForAlert(projection.estimatedRevenueSek)}, min SOC ${round1(projection.minSocPercent)}%`,
+    });
+  });
+
+  let previousSettledDate: string | undefined;
+  createEffect(() => {
+    const settlement = ctx.autoTraderStatus()?.last_settlement;
+    const previous = previousSettledDate;
+    previousSettledDate = settlement?.date;
+    if (!settlement || previous === undefined || settlement.date === previous) return;
+    if (!untrack(alerting).digest_p3) return;
+    void ctx.manager.raise({
+      key: "settlement-digest",
+      severity: "P3",
+      title: `Settled ${settlement.date}`,
+      message: `Realized ${formatSekForAlert(settlement.realized_revenue_sek)} (exported ${settlement.export_kwh} kWh, imported ${settlement.import_kwh} kWh)`,
+    });
+  });
+}

--- a/backend/src/alerting/alerting.selftest.ts
+++ b/backend/src/alerting/alerting.selftest.ts
@@ -1,0 +1,89 @@
+/**
+ * Self-test for the pure alerting decision logic. Run from backend/ with:
+ *   yarn node src/alerting/alerting.selftest.ts
+ */
+import { decideSend, errorLogDedupeKey, severityToPushoverPriority, thresholdState } from "./alertingLogic.ts";
+
+let failures = 0;
+function check(name: string, actual: unknown, expected: unknown) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (!ok) {
+    failures++;
+    console.error(`FAIL ${name}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  } else {
+    console.log(`ok   ${name}`);
+  }
+}
+
+// ——— severity → Pushover mapping ———
+check("P1 is emergency priority with retry/expire", severityToPushoverPriority("P1"), {
+  priority: 2,
+  retry: 60,
+  expire: 3600,
+});
+check("P2 is a normal push", severityToPushoverPriority("P2"), { priority: 0 });
+check("P3 is quiet", severityToPushoverPriority("P3"), { priority: -1 });
+
+// ——— cooldown / escalation / rate cap ———
+const base = { nowMs: 1_000_000, cooldownMs: 30 * 60_000, pushedAtMsLastHour: [] as number[], maxPushesPerHour: 20 };
+
+check("first alert sends", decideSend({ ...base, severity: "P2" }), "send");
+check(
+  "same key within cooldown is suppressed",
+  decideSend({ ...base, severity: "P2", lastSentForKey: { atMs: base.nowMs - 60_000, severity: "P2" } }),
+  "cooldown"
+);
+check(
+  "escalation to P1 bypasses the cooldown",
+  decideSend({ ...base, severity: "P1", lastSentForKey: { atMs: base.nowMs - 60_000, severity: "P2" } }),
+  "send"
+);
+check(
+  "de-escalation stays suppressed",
+  decideSend({ ...base, severity: "P3", lastSentForKey: { atMs: base.nowMs - 60_000, severity: "P2" } }),
+  "cooldown"
+);
+check(
+  "same key after the cooldown sends again",
+  decideSend({ ...base, severity: "P2", lastSentForKey: { atMs: base.nowMs - 31 * 60_000, severity: "P2" } }),
+  "send"
+);
+const fullHour = Array.from({ length: 20 }, (_, i) => base.nowMs - i * 1000);
+check("P2 hits the hourly cap", decideSend({ ...base, severity: "P2", pushedAtMsLastHour: fullHour }), "rate_capped");
+check(
+  "P1 is exempt from the hourly cap",
+  decideSend({ ...base, severity: "P1", pushedAtMsLastHour: fullHour }),
+  "send"
+);
+
+// ——— hysteresis ———
+check("above set threshold → active", thresholdState(97.2, 97, 92), true);
+check("inside the gap → hold", thresholdState(94, 97, 92), undefined);
+check("below clear threshold → inactive", thresholdState(91.9, 97, 92), false);
+check("inverted (undervoltage) set", thresholdState(-45.9, -46, -47), true);
+check("inverted (undervoltage) hold", thresholdState(-46.5, -46, -47), undefined);
+check("inverted (undervoltage) clear", thresholdState(-47.1, -46, -47), false);
+
+// ——— errorLog dedupe keys ———
+check(
+  "same error with different numbers dedupes to one key",
+  errorLogDedupeKey(["Price API returned 503 after 60000ms"]) ===
+    errorLogDedupeKey(["Price API returned 502 after 31ms"]),
+  true
+);
+check(
+  "different errors get different keys",
+  errorLogDedupeKey(["Auto trader errored"]) === errorLogDedupeKey(["Current measuring errored"]),
+  false
+);
+check(
+  "Error instances key on their message",
+  errorLogDedupeKey([new Error("boom 123")]) === errorLogDedupeKey([new Error("boom 456")]),
+  true
+);
+
+if (failures) {
+  console.error(`\n${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("\nAll alerting logic checks passed");

--- a/backend/src/alerting/alerting.types.ts
+++ b/backend/src/alerting/alerting.types.ts
@@ -1,0 +1,32 @@
+/**
+ * Pure type declarations for alerting, shared over the ws boundary (the /system alerts card
+ * renders AlertRecord[]) — no runtime imports, see CLAUDE.md on shared wire types.
+ */
+
+/**
+ * P1 pages everyone through DND (Pushover emergency priority + Critical Alerts), P2 is a normal
+ * push, P3 is silent/informational. Extend here when a new tier is needed — everything maps
+ * severities through alertingLogic.severityToPushoverPriority.
+ */
+export type AlertSeverity = "P1" | "P2" | "P3";
+
+export type AlertDelivery =
+  | "pushed"
+  | "dry_run"
+  | "push_failed"
+  | "rate_capped"
+  | "cooldown"
+  | "unconfigured"
+  | "disabled";
+
+export type AlertRecord = {
+  key: string;
+  severity: AlertSeverity;
+  title: string;
+  message: string;
+  /** ISO timestamp of when the alert fired */
+  at: string;
+  delivery: AlertDelivery;
+  /** Transport detail on failures ("invalid token", timeouts, …) */
+  detail?: string;
+};

--- a/backend/src/alerting/alertingLogic.ts
+++ b/backend/src/alerting/alertingLogic.ts
@@ -1,0 +1,109 @@
+import type { AlertSeverity } from "./alerting.types.ts";
+
+/**
+ * The pure decision core of alerting — no IO, no clock reads — so cooldown/escalation/rate-cap
+ * behavior is testable in alerting.selftest.ts. The manager owns state and side effects.
+ */
+
+const SEVERITY_RANK: Record<AlertSeverity, number> = { P1: 3, P2: 2, P3: 1 };
+
+export function severityRank(severity: AlertSeverity): number {
+  return SEVERITY_RANK[severity];
+}
+
+/**
+ * Pushover mapping: P1 = emergency priority (repeats every 60 s for an hour until someone
+ * acknowledges; devices with Critical Alerts enabled ring through mute/DND), P2 = normal push,
+ * P3 = quiet (no sound or vibration).
+ */
+export function severityToPushoverPriority(severity: AlertSeverity): {
+  priority: number;
+  retry?: number;
+  expire?: number;
+} {
+  if (severity === "P1") return { priority: 2, retry: 60, expire: 3600 };
+  if (severity === "P2") return { priority: 0 };
+  return { priority: -1 };
+}
+
+export type SendDecision = "send" | "cooldown" | "rate_capped";
+
+export function decideSend(input: {
+  nowMs: number;
+  severity: AlertSeverity;
+  lastSentForKey?: { atMs: number; severity: AlertSeverity };
+  cooldownMs: number;
+  /** Timestamps of every push in the last hour (pruned by the caller) */
+  pushedAtMsLastHour: number[];
+  maxPushesPerHour: number;
+}): SendDecision {
+  const { lastSentForKey } = input;
+  if (
+    lastSentForKey &&
+    input.nowMs - lastSentForKey.atMs < input.cooldownMs &&
+    severityRank(input.severity) <= severityRank(lastSentForKey.severity)
+  ) {
+    return "cooldown";
+  }
+  // P1 must never be silenced by a chatty P2 bug — only the per-key cooldown applies to it
+  if (input.severity !== "P1" && input.pushedAtMsLastHour.length >= input.maxPushesPerHour) {
+    return "rate_capped";
+  }
+  return "send";
+}
+
+/**
+ * Dedupe key for forwarded errorLog() calls: the same logical error must map to the same key even
+ * when it embeds timestamps, readings or ports, so digits collapse to '#'. Two args are enough
+ * context — later args tend to be whole error objects.
+ */
+export function errorLogDedupeKey(args: unknown[]): string {
+  const text = args
+    .slice(0, 2)
+    .map(argument =>
+      typeof argument === "string" ? argument : argument instanceof Error ? argument.message : safeStringify(argument)
+    )
+    .join(" ")
+    .replace(/\d+/g, "#");
+  return `errorlog:${text.slice(0, 80)}`;
+}
+
+export function formatErrorLogMessage(args: unknown[]): string {
+  return args
+    .map(argument =>
+      typeof argument === "string"
+        ? argument
+        : argument instanceof Error
+          ? argument.stack?.split("\n").slice(0, 2).join(" ") ?? argument.message
+          : safeStringify(argument)
+    )
+    .join(" ")
+    .slice(0, 900); // Pushover messages cap at 1024 chars
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Tri-state threshold with a set/clear gap: `true` at/above `setAt`, `false` at/below `clearAt`,
+ * `undefined` (= hold the previous state) in between — the gap absorbs sensor noise hovering at
+ * the line. For "alert when low" checks, negate value and both bounds.
+ */
+export function thresholdState(value: number, setAt: number, clearAt: number): boolean | undefined {
+  if (value >= setAt) return true;
+  if (value <= clearAt) return false;
+  return undefined;
+}
+
+export function round1(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+export function formatSekForAlert(sek: number): string {
+  return `${sek > 0 ? "+" : ""}${round1(sek)} SEK`;
+}

--- a/backend/src/alerting/pushoverTransport.ts
+++ b/backend/src/alerting/pushoverTransport.ts
@@ -1,0 +1,51 @@
+import { warnLog } from "../utilities/logging.ts";
+
+/**
+ * One Pushover message. Never throws and never calls errorLog — the alert manager forwards
+ * errorLog() calls as alerts, so a failing transport logging through errorLog would recurse.
+ */
+export async function sendPushoverMessage(params: {
+  token: string;
+  user: string;
+  title: string;
+  message: string;
+  priority: number;
+  /** Seconds between re-delivery attempts (emergency priority only, min 30) */
+  retry?: number;
+  /** Seconds until an unacknowledged emergency alert stops repeating */
+  expire?: number;
+}): Promise<{ ok: boolean; detail?: string }> {
+  const body = new URLSearchParams({
+    token: params.token,
+    user: params.user,
+    title: params.title,
+    message: params.message,
+    priority: String(params.priority),
+  });
+  if (params.priority === 2) {
+    body.set("retry", String(params.retry ?? 60));
+    body.set("expire", String(params.expire ?? 3600));
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15_000);
+  try {
+    const response = await fetch("https://api.pushover.net/1/messages.json", {
+      method: "POST",
+      body,
+      signal: controller.signal,
+    });
+    if (response.ok) return { ok: true };
+    const detail = await response
+      .json()
+      .then((parsed: { errors?: string[] }) => parsed.errors?.join("; ") ?? `HTTP ${response.status}`)
+      .catch(() => `HTTP ${response.status}`);
+    warnLog("Alerting: Pushover rejected message", detail);
+    return { ok: false, detail };
+  } catch (e) {
+    warnLog("Alerting: Pushover request failed", e);
+    return { ok: false, detail: String(e).slice(0, 200) };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -10,6 +10,27 @@ import type { Config } from "./config.types.ts";
 const INVERTER_NAMEPLATE_AC_WATTS = 15000;
 
 export const default_config: Config = {
+  alerting: {
+    enabled: true,
+    dry_run: true,
+    pushover_app_token: "",
+    pushover_recipient_key: "",
+    site_name: "",
+    battery_temp_p1_celsius: 45,
+    inverter_temp_p1_celsius: 97,
+    battery_undervoltage_p2_volts: 46,
+    battery_overvoltage_p1_volts: 58.8,
+    charging_battery_temp_p1_celsius: 1,
+    stale_mqtt_p2_minutes: 5,
+    stale_temperatures_p2_minutes: 10,
+    grid_out_below_volts: 100,
+    grid_out_p2_seconds: 60,
+    error_log_p2: true,
+    digest_p3: true,
+    cooldown_minutes: 30,
+    max_pushes_per_hour: 20,
+    startup_grace_seconds: 180,
+  },
   automatic_trading: {
     enabled: false,
     price_area: "SE3",
@@ -148,17 +169,17 @@ export const default_config: Config = {
 };
 
 /**
- * Top-level keys merge shallowly, but automatic_trading, elpatron_switching and soc_calculations
- * merge one level deeper: knobs get added over time, and a config.json written before a knob
- * existed must still pick up its default (the planner, the elpatron load model and the SOC
- * ledgers do raw arithmetic on these — a missing knob would silently NaN every projection).
- * soc_calculations.ah_ledger (and its soft_empty) is the newest such section, so a config
- * predating it still boots with the validated defaults.
+ * Top-level keys merge shallowly, but alerting, automatic_trading, elpatron_switching and
+ * soc_calculations merge one level deeper: knobs get added over time, and a config.json written
+ * before a knob existed must still pick up its default (the planner, the elpatron load model and
+ * the SOC ledgers do raw arithmetic on these — a missing knob would silently NaN every
+ * projection; a missing alerting threshold would silently never alert).
  */
 function mergeWithDefaults(partial: Partial<Config>): Config {
   return {
     ...default_config,
     ...partial,
+    alerting: { ...default_config.alerting, ...partial.alerting },
     automatic_trading: { ...default_config.automatic_trading, ...partial.automatic_trading },
     elpatron_switching: { ...default_config.elpatron_switching, ...partial.elpatron_switching },
     soc_calculations: {

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -18,6 +18,7 @@ export const default_config: Config = {
     site_name: "",
     battery_temp_p1_celsius: 45,
     inverter_temp_p1_celsius: 97,
+    cooling_outlet_temp_p2_celsius: 36,
     battery_undervoltage_p2_volts: 46,
     battery_overvoltage_p1_volts: 58.8,
     charging_battery_temp_p1_celsius: 1,

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -30,6 +30,7 @@ export const default_config: Config = {
     digest_p3: true,
     cooldown_minutes: 30,
     max_pushes_per_hour: 20,
+    max_errorlog_pushes_per_hour: 6,
     startup_grace_seconds: 180,
   },
   automatic_trading: {

--- a/backend/src/config/config.types.ts
+++ b/backend/src/config/config.types.ts
@@ -114,6 +114,8 @@ export type AlertingConfig = {
   cooldown_minutes: number;
   /** Global cap (P1 exempt) so a bug can't machine-gun the family or the API quota */
   max_pushes_per_hour: number;
+  /** Separate hourly budget for forwarded-errorLog P2s so log noise can't crowd out threshold-rule alerts */
+  max_errorlog_pushes_per_hour: number;
   /** No staleness alerts this soon after boot — sensors come up in their own time */
   startup_grace_seconds: number;
 };

--- a/backend/src/config/config.types.ts
+++ b/backend/src/config/config.types.ts
@@ -85,6 +85,13 @@ export type AlertingConfig = {
   battery_temp_p1_celsius: number;
   /** P1 when component_max_temperature reaches this — the inverter hard-shuts-off at 100 °C */
   inverter_temp_p1_celsius: number;
+  /**
+   * P2 when the hottest cooling_outlet_* probe reaches this — the early ventilation alarm. In the
+   * 2025-06-30 shutdown (door + ventilation accidentally closed) outlets hit 39–41 °C vs a 34 °C
+   * normal-summer peak, and would have crossed 36 °C ~80 min before the 100 °C cutoff. The
+   * external-inlet probe sat flat at 24.5 °C through it, so it can't be the signal.
+   */
+  cooling_outlet_temp_p2_celsius: number;
   /** P2 below this pack voltage (16s LiFePO4 tolerates down to 2.5 V/cell = 40 V) */
   battery_undervoltage_p2_volts: number;
   /** P1 above this pack voltage (3.65 V/cell = 58.4 V is the charge ceiling) */

--- a/backend/src/config/config.types.ts
+++ b/backend/src/config/config.types.ts
@@ -70,8 +70,50 @@ export type AutomaticTradingConfig = {
   };
 };
 
+export type AlertingConfig = {
+  /** Master switch — rules still run but nothing is recorded or sent when off */
+  enabled: boolean;
+  /** Log what would have been pushed instead of pushing (burn-in mode; cooldowns behave as live) */
+  dry_run: boolean;
+  /** Application API token from pushover.net/apps */
+  pushover_app_token: string;
+  /** A Pushover delivery-group key (whole family) or a single user key */
+  pushover_recipient_key: string;
+  /** Prefixed to every title so Örebro and Göteborg pushes are tellable apart */
+  site_name: string;
+  /** P1 when any battery probe (cell/bus-bar thermometers) reaches this; clears 3° lower */
+  battery_temp_p1_celsius: number;
+  /** P1 when component_max_temperature reaches this — the inverter hard-shuts-off at 100 °C */
+  inverter_temp_p1_celsius: number;
+  /** P2 below this pack voltage (16s LiFePO4 tolerates down to 2.5 V/cell = 40 V) */
+  battery_undervoltage_p2_volts: number;
+  /** P1 above this pack voltage (3.65 V/cell = 58.4 V is the charge ceiling) */
+  battery_overvoltage_p1_volts: number;
+  /** P1 when charging > 200 W with any battery probe at/below this (no charging below freezing) */
+  charging_battery_temp_p1_celsius: number;
+  /** P2 when no mqtt value has updated for this long (inverter USB daemon dead) */
+  stale_mqtt_p2_minutes: number;
+  /** P2 when every thermometer has been silent for this long */
+  stale_temperatures_p2_minutes: number;
+  /** Grid counts as down when ac_input_voltage_r sits below this … */
+  grid_out_below_volts: number;
+  /** … for at least this long (P2) */
+  grid_out_p2_seconds: number;
+  /** Forward every errorLog() as a deduped P2 */
+  error_log_p2: boolean;
+  /** Quiet P3 pushes for the daily plan + settlement results */
+  digest_p3: boolean;
+  /** Per-alert-key re-send suppression window */
+  cooldown_minutes: number;
+  /** Global cap (P1 exempt) so a bug can't machine-gun the family or the API quota */
+  max_pushes_per_hour: number;
+  /** No staleness alerts this soon after boot — sensors come up in their own time */
+  startup_grace_seconds: number;
+};
+
 export type Config = {
   automatic_trading: AutomaticTradingConfig;
+  alerting: AlertingConfig;
   usb_parameter_setting: {
     min_seconds_between_commands: number;
     /**

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -30,6 +30,8 @@ import { InfluxClientProvider } from "./utilities/InfluxClientProvider.ts";
 import { useAutoTrader } from "./autoTrading/autoTrader.ts";
 import { latestSpotPrices } from "./autoTrading/priceService.ts";
 import { pollSpotPricesForFrontend } from "./autoTrading/spotPricePolling.ts";
+import { alertOnMainCrash, createAlertManager } from "./alerting/alertManager.ts";
+import { startAlertRules } from "./alerting/alertRules.ts";
 
 while (true) {
   await new Promise<void>(r => {
@@ -44,6 +46,8 @@ while (true) {
         },
         e => {
           errorLog("Main crashed, restarting in 10s", e);
+          // Also escalates: a second crash within 30 min pages as P1 (crash loop = controller down)
+          alertOnMainCrash(e);
           dispose();
           r();
         }
@@ -56,7 +60,6 @@ while (true) {
 function main() {
   // TODO: consider how much sun is shining in when full current if-statement
   // TODO: limit discharge current as voltage gets lower and limit charge current as voltage gets higher
-  // TODO: Alerts when battery overheats / program restarts
   // TODO: add typecheck CI pipeline
   // TODO: when battery completely empty and essentially disconnected for everything except charging, don't count inverter idle consumption as coming from the battery
   const owner = getOwner()!;
@@ -157,6 +160,24 @@ function main() {
                       );
                     });
 
+                    const { mqttValues } = useFromMqttProvider();
+                    const alertManager = createAlertManager(config);
+                    catchError(
+                      () =>
+                        startAlertRules({
+                          config,
+                          manager: alertManager,
+                          temperatures,
+                          mqttValues,
+                          averageSOC: clampedAverageSOC,
+                          currentBatteryPower: currentPower,
+                          autoTraderStatus: () => autoTrader()?.autoTraderStatus(),
+                        }),
+                      // Alerting going down must never take the controller with it — and this failure
+                      // is itself worth a push, which the errorLog hook provides.
+                      e => errorLog("Alert rules crashed — alerting rules disabled until restart", e)
+                    );
+
                     const isChargingOuterScope = createMemo(() => {
                       if (!hasCredentials()) {
                         return errorLog(
@@ -216,7 +237,6 @@ function main() {
 
                       return isCharging;
                     });
-                    const { mqttValues } = useFromMqttProvider();
                     // Memo (not effect) so the returned live heater state can be exposed over the ws
                     const elpatronReturn = createMemo(() => {
                       if (elpatronSwitchingErrored()) return;
@@ -245,10 +265,21 @@ function main() {
                             if (!trader) return "auto trader not running";
                             return await trader.clearTradingVetoes();
                           },
+                          send_test_alert: async () => {
+                            const record = await alertManager.raise({
+                              key: "test-alert",
+                              severity: "P2",
+                              title: "Test alert",
+                              message:
+                                "Manual test from the dashboard — if you can read this on your phone, alerting works",
+                            });
+                            return `delivery: ${record.delivery}${record.detail ? ` (${record.detail})` : ""}`;
+                          },
                         },
                         exposedAccessors: {
                           autoTraderStatus: () => autoTrader()?.autoTraderStatus(),
                           spotPrices: latestSpotPrices,
+                          recentAlerts: alertManager.recentAlerts,
                           energyAddedSinceEmpty,
                           lastFeedWhenNoSolarReason,
                           lastChangingFeedWhenNoSolarReason,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -267,7 +267,9 @@ function main() {
                           },
                           send_test_alert: async () => {
                             const record = await alertManager.raise({
-                              key: "test-alert",
+                              // Unique per press: re-testing a silent phone is the whole point, so the
+                              // cooldown must never swallow a manual test (review: PR #37).
+                              key: `test-alert-${Date.now()}`,
                               severity: "P2",
                               title: "Test alert",
                               message:

--- a/backend/src/utilities/logging.ts
+++ b/backend/src/utilities/logging.ts
@@ -11,6 +11,19 @@ export function warnLog(...args: any[]) {
 }
 export function errorLog(...args: any[]) {
   print("error", "[ERROR]", ...args);
+  // Forwarded to alerting (P2 push) when registered. Listener errors must never break logging.
+  try {
+    onErrorLogListener?.(args);
+  } catch {
+    /* a listener that throws gets no better treatment than silence — logging must stay bulletproof */
+  }
+}
+
+let onErrorLogListener: ((args: any[]) => void) | undefined;
+
+/** Alerting registers here to turn every errorLog into a (deduped) push notification. */
+export function setOnErrorLog(listener: ((args: any[]) => void) | undefined) {
+  onErrorLogListener = listener;
 }
 
 export function debugLog(...args: any[]) {

--- a/frontend/src/components/system/AlertsCard.scss
+++ b/frontend/src/components/system/AlertsCard.scss
@@ -1,0 +1,88 @@
+.alerts-card__empty {
+  margin: 2px 0 10px;
+  font-size: 12.5px;
+  color: var(--ink-2);
+}
+
+.alerts-card__list {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 12px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.alerts-card__row {
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+  font-size: 12.5px;
+  border-bottom: 1px solid var(--line-soft);
+  padding-bottom: 6px;
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.alerts-card__severity {
+  flex: none;
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 700;
+  border-radius: 5px;
+  padding: 1px 6px;
+  background: var(--line-soft);
+  color: var(--ink-2);
+}
+
+.alerts-card__severity--p1 {
+  background: var(--crit);
+  color: light-dark(#ffffff, #0e1412);
+}
+
+.alerts-card__severity--p2 {
+  background: var(--chip-warn-bg);
+  color: var(--warn-text);
+}
+
+.alerts-card__text {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--ink-2);
+
+  b {
+    color: var(--ink);
+    font-weight: 600;
+  }
+}
+
+.alerts-card__meta {
+  margin-left: auto;
+  flex: none;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--ink-3);
+  white-space: nowrap;
+}
+
+.alerts-card__test-btn {
+  font: inherit;
+  font-weight: 600;
+  font-size: 12.5px;
+  padding: 7px 14px;
+  border-radius: 6px;
+  border: 1px solid var(--line);
+  background: var(--card);
+  color: var(--ink);
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    border-color: var(--ink-3);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+}

--- a/frontend/src/components/system/AlertsCard.tsx
+++ b/frontend/src/components/system/AlertsCard.tsx
@@ -1,0 +1,84 @@
+import { createSignal, For, getOwner, Show } from "solid-js";
+import { getBackendSyncedSignal, sendBackendAction } from "~/helpers/getBackendSyncedSignal";
+import { showToastWithMessage } from "~/helpers/showToastWithMessage";
+import { useWebSocket } from "~/components/WebSocketProvider";
+import { formatRelativeTime, useNowMs } from "~/helpers/format";
+import type { AlertRecord } from "../../../../backend/src/alerting/alerting.types";
+import type { Config } from "../../../../backend/src/config/config.types";
+import "./AlertsCard.scss";
+
+/**
+ * Recent alerts as the controller saw them (including dry-run and suppressed ones), plus the test
+ * button every family phone gets verified with. Thresholds live in the alerting config section.
+ */
+export function AlertsCard() {
+  const [recentAlerts] = getBackendSyncedSignal<AlertRecord[]>("recentAlerts", undefined, true, true);
+  const [config] = getBackendSyncedSignal<Config>("config", undefined, false);
+  const socket = useWebSocket();
+  const owner = getOwner()!;
+  const now = useNowMs(5000);
+  const [sending, setSending] = createSignal(false);
+
+  const alertingConfig = () => config()?.alerting;
+
+  return (
+    <section class="card alerts-card" aria-label="Alerts">
+      <div class="card-head">
+        <span class="eyebrow">Alerts</span>
+        <Show when={alertingConfig()}>
+          {alerting => (
+            <span class="card-meta">
+              {alerting().dry_run
+                ? "dry run — logging instead of pushing"
+                : alerting().pushover_app_token
+                  ? "pushing via Pushover"
+                  : "no Pushover tokens configured"}
+            </span>
+          )}
+        </Show>
+      </div>
+
+      <Show
+        when={recentAlerts()?.length}
+        fallback={<p class="alerts-card__empty">Nothing yet — quiet controller, happy controller.</p>}
+      >
+        <div class="alerts-card__list">
+          <For each={recentAlerts()}>
+            {alert => (
+              <div class="alerts-card__row" title={alert.detail}>
+                <span class={`alerts-card__severity alerts-card__severity--${alert.severity.toLowerCase()}`}>
+                  {alert.severity}
+                </span>
+                <span class="alerts-card__text">
+                  <b>{alert.title}</b> {alert.message}
+                </span>
+                <span class="alerts-card__meta">
+                  {formatRelativeTime(now(), +new Date(alert.at))} · {alert.delivery}
+                </span>
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
+
+      <button
+        type="button"
+        class="alerts-card__test-btn"
+        disabled={sending()}
+        onClick={async () => {
+          setSending(true);
+          try {
+            const result = await sendBackendAction(socket, "send_test_alert");
+            await showToastWithMessage(owner, () => `Test alert — ${result}`);
+          } catch (e) {
+            await showToastWithMessage(owner, () => `Test alert failed: ${e}`);
+          } finally {
+            setSending(false);
+          }
+        }}
+      >
+        {sending() ? "Sending…" : "Send test alert"}
+      </button>
+    </section>
+  );
+}

--- a/frontend/src/routes/system.tsx
+++ b/frontend/src/routes/system.tsx
@@ -1,6 +1,7 @@
 import { Title } from "@solidjs/meta";
 import { LiveReadings } from "~/components/system/LiveReadings";
 import { DiagnosticsCards } from "~/components/system/DiagnosticsCards";
+import { AlertsCard } from "~/components/system/AlertsCard";
 import "./system.scss";
 
 /** Live data + diagnostics merged: raw sensor truth on top, controller internals below. */
@@ -9,6 +10,8 @@ export default function System() {
     <main class="system">
       <Title>System — Kraftverket</Title>
       <h1>System</h1>
+      <h2 class="system__heading">Alerts</h2>
+      <AlertsCard />
       <h2 class="system__heading">Live readings</h2>
       <LiveReadings />
       <h2 class="system__heading">Controller internals</h2>


### PR DESCRIPTION
Stacked on #34.

## Severity contract
- **P1** → Pushover emergency priority: repeats every 60 s until someone acknowledges, and rings through mute/Focus on iPhones with Critical Alerts enabled in the Pushover app.
- **P2** → normal push notification.
- **P3** → quiet (no sound) — digests and resolution notices.

## Rules
| Rule | Severity | Notes |
|---|---|---|
| Battery probe (cell/bus-bar) temp | P1 ≥ 45 °C | clears 3° lower; P3 resolve notice |
| Inverter `component_max_temperature` | P1 ≥ 97 °C | it hard-shuts-off at 100 °C, so 97 = imminent |
| Battery voltage | P2 < 46 V / P1 > 58.8 V | 16s LiFePO4: cells tolerate 40 V, so low is a warning |
| Charging below freezing | P1 | > 200 W charge with any probe ≤ 1 °C |
| SOC < emergency floor while discharging | P2 | means the trading guard failed |
| mqtt / thermometer staleness | P2 | 5 / 10 min, with startup grace |
| Grid out (`ac_input_voltage_r` < 100 V ≥ 60 s) | P2 | P3 "restored" notice |
| Trading guard intervened | P2 | watched via the status signal — no trader changes |
| Daily plan + settlement digests | P3 | opt-out via `digest_p3` |
| **Any `errorLog()` anywhere** | P2 | deduped (digits collapse), so plan failures/subsystem crashes alert without touching call sites |
| `main()` crash | P2 → P1 | escalates when it crashes twice in 30 min |

## Manager behavior
Per-key cooldown (30 min; severity escalation bypasses), hourly rate cap (20, P1 exempt), hysteresis via `thresholdState`, persisted `alert_state.json` so the restart an alert causes can't re-fire it, `dry_run` for burn-in. Pure decision logic in `alertingLogic.ts` + `alerting.selftest.ts` (cooldown/escalation/rate-cap/hysteresis/dedupe). Transport never throws and never `errorLog`s (that would recurse into itself).

**Deploying this is a no-op**: defaults are `enabled + dry_run` with empty tokens. Going live = paste `pushover_app_token` + `pushover_recipient_key` (a delivery-group key) into the new `alerting` config section, set `site_name`, flip `dry_run` off after burn-in.

Frontend: alerts card on /system (recent alerts incl. dry-run/suppressed ones) + "Send test alert" button for verifying each family phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2FhRs8m1oPqWvJc3kTgBu

---
_Recreated after #34's squash-merge deleted the old base branch (GitHub closed #35 instead of retargeting); branch rebased onto main._