### PR TITLE
Trading page redesign: one staging model, floors with explanations, unified schedule

### DIFF
--- a/backend/src/autoTrading/autoTrader.ts
+++ b/backend/src/autoTrading/autoTrader.ts
@@ -250,6 +250,7 @@ function refreshStatus(ctx: TraderCtx, extra?: Partial<AutoTraderStatus>) {
       last_settlement: ctx.state.last_settlement,
       owned_selling_windows: Object.keys(ctx.state.owned_entries.selling).length,
       owned_buying_windows: Object.keys(ctx.state.owned_entries.buying).length,
+      owned_entries: ctx.state.owned_entries,
       ...extra,
     }))
   );

--- a/backend/src/autoTrading/autoTraderState.types.ts
+++ b/backend/src/autoTrading/autoTraderState.types.ts
@@ -84,4 +84,10 @@ export type AutoTraderStatus = {
   last_settlement?: AutoTraderState["last_settlement"];
   owned_selling_windows?: number;
   owned_buying_windows?: number;
+  /**
+   * The ownership record itself, so the frontend can badge exactly the schedule entries the trader
+   * owns — last_plan.windows is a lossy proxy (a window kept through a keepActiveWindows replan is
+   * owned but absent from the latest plan's windows).
+   */
+  owned_entries?: AutoTraderState["owned_entries"];
 };

--- a/frontend/src/components/AutoTraderPanel.tsx
+++ b/frontend/src/components/AutoTraderPanel.tsx
@@ -53,22 +53,6 @@ export function AutoTraderPanel() {
           }
         </p>
 
-        <div class="buy-sell-config__grid2">
-          <label class="buy-sell-config__label">
-            Extra reserve to keep in battery (kWh), e.g. for car charging
-            <input
-              class="buy-sell-config__input"
-              type="number"
-              min="0"
-              step="1"
-              value={tradingConfig()?.extra_reserve_kwh ?? 0}
-              onChange={e =>
-                void writeTradingConfig({ extra_reserve_kwh: Math.max(0, parseFloat(e.currentTarget.value) || 0) })
-              }
-            />
-          </label>
-        </div>
-
         <Show when={status()!.last_plan}>
           {plan => (
             <>

--- a/frontend/src/components/BuySellConfig.scss
+++ b/frontend/src/components/BuySellConfig.scss
@@ -73,6 +73,16 @@
   font-size: 0.9rem;
 }
 
+.buy-sell-config__unit {
+  color: var(--ink-3);
+}
+
+.buy-sell-config__help {
+  font-size: 0.78rem;
+  color: var(--ink-2);
+  line-height: 1.45;
+}
+
 .buy-sell-config__input {
   padding: 0.45rem 0.5rem;
   border: 1px solid var(--line);
@@ -199,6 +209,75 @@
 .buy-sell-config__earn {
   color: var(--ok-text);
   font-variant-numeric: tabular-nums;
+}
+
+.buy-sell-config__td-kind {
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+.buy-sell-config__kind {
+  display: inline-block;
+  font-weight: 650;
+  font-size: 0.8rem;
+  border-radius: 999px;
+  padding: 2px 10px;
+}
+
+.buy-sell-config__kind--sell {
+  background: var(--chip-ok-bg);
+  color: var(--ok-text);
+}
+
+.buy-sell-config__kind--buy {
+  background: var(--band-buy);
+  color: var(--buy-text);
+}
+
+.buy-sell-config__kind-inline {
+  margin: 0 0.3em;
+  font-size: 0.8em;
+  color: var(--ok-text);
+  white-space: nowrap;
+}
+
+.buy-sell-config__planned {
+  display: block;
+  margin-top: 3px;
+  font-size: 0.72rem;
+  color: var(--ok-text);
+  white-space: nowrap;
+}
+
+.buy-sell-config__add-btns {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.buy-sell-config__savebar {
+  position: sticky;
+  bottom: 12px;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  background: var(--card);
+  border: 1px solid var(--battery);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 10px 14px;
+}
+
+.buy-sell-config__savebar-text {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.buy-sell-config__savebar-actions {
+  display: flex;
+  gap: 0.6rem;
 }
 
 .buy-sell-config__sr-only {

--- a/frontend/src/components/BuySellConfigForm.tsx
+++ b/frontend/src/components/BuySellConfigForm.tsx
@@ -1,31 +1,56 @@
-import { createForm, getValues, insert, remove, setValues, zodForm } from "@modular-forms/solid";
-import type { Accessor } from "solid-js";
-import { createEffect, createMemo, For, Show, getOwner, untrack } from "solid-js";
+import {
+  createForm,
+  Field,
+  FieldArray,
+  getValues,
+  insert,
+  remove,
+  reset,
+  setValues,
+  zodForm,
+  type FieldPath,
+  type FormStore,
+} from "@modular-forms/solid";
+import type { Accessor, JSX } from "solid-js";
+import { createEffect, createMemo, For, getOwner, Show, untrack } from "solid-js";
 import { getBackendSyncedSignal } from "~/helpers/getBackendSyncedSignal";
 import { showToastWithMessage } from "~/helpers/showToastWithMessage";
-import { configToBuySellFormData, diffMergeFormIntoConfig, type BuySellFormData } from "~/helpers/buySellConfigMapping";
+import {
+  configToBuySellFormData,
+  diffMergeFormIntoConfig,
+  isoToDatetimeLocal,
+  type BuySellFormData,
+  type BuySellScheduleRow,
+  type ScheduleRowKind,
+} from "~/helpers/buySellConfigMapping";
 import { buySellFormSchema } from "~/helpers/buySellFormSchema";
 import { formatDurationLabel, rowDurationHours, rowEnergyKwh } from "~/helpers/scheduleRowDerived";
 import type { Config } from "../../../backend/src/config/config.types";
+import type { AutoTraderStatus, StateWindow } from "../../../backend/src/autoTrading/autoTraderState.types";
 import "./BuySellConfig.scss";
 
-const emptyRow = (): BuySellFormData["buyingRows"][number] => ({
-  start: "",
-  end: "",
-  power: 0,
-});
+type BuySellForm = FormStore<BuySellFormData, undefined>;
 
-function duplicateScheduleRow(
-  form: ReturnType<typeof createForm<BuySellFormData>>[0],
-  kind: "buyingRows" | "sellingRows",
-  atIndex: number
-) {
-  const v = getValues(form);
-  const row = v[kind]?.[atIndex];
+/** New rows start at the next full hour, one hour long, at a kind-appropriate default power. */
+function emptyRow(kind: ScheduleRowKind, config: Config): BuySellScheduleRow {
+  const start = new Date();
+  start.setMinutes(60, 0, 0);
+  const end = new Date(+start + 3600_000);
+  const power =
+    kind === "sell"
+      ? config.automatic_trading?.max_sell_power_watts ?? 15000
+      : config.automatic_trading?.max_buy_power_watts ?? 3000;
+  return { kind, start: isoToDatetimeLocal(start.toISOString()), end: isoToDatetimeLocal(end.toISOString()), power };
+}
+
+function duplicateScheduleRow(form: BuySellForm, atIndex: number) {
+  const values = getValues(form);
+  const row = values.rows?.[atIndex];
   if (!row) return;
-  insert(form, kind, {
+  insert(form, "rows", {
     at: atIndex + 1,
     value: {
+      kind: (row.kind as ScheduleRowKind) ?? "sell",
       start: row.start ?? "",
       end: row.end ?? "",
       power: row.power ?? 0,
@@ -42,29 +67,62 @@ function fieldValueForInput(field: { value: unknown }): string | number {
 }
 
 function buySellSliceKey(c: Config): string {
+  const t = c.automatic_trading;
   return JSON.stringify({
     scheduled_power_buying: c.scheduled_power_buying,
     scheduled_power_selling: c.scheduled_power_selling,
+    floors: [t.emergency_soc_floor_percent, t.planner_soc_floor_percent, t.planner_soc_floor_sunny_percent],
+    reserve: t.extra_reserve_kwh,
   });
 }
 
-function ScheduleRowMeta(props: {
-  form: ReturnType<typeof createForm<BuySellFormData>>[0];
-  kind: "buyingRows" | "sellingRows";
-  index: number;
+/** A labelled number input with its explanation underneath — the whole form is made of these. */
+function NumberField(props: {
+  form: BuySellForm;
+  name: FieldPath<BuySellFormData>;
+  label: string;
+  unit: string;
+  help: string;
+  min?: number;
+  max?: number;
 }) {
+  return (
+    <label class="buy-sell-config__label">
+      <span>
+        {props.label} <span class="buy-sell-config__unit">({props.unit})</span>
+      </span>
+      <Field of={props.form} name={props.name} type="number">
+        {(field, p) => (
+          <>
+            <input
+              {...p}
+              value={fieldValueForInput(field)}
+              class="buy-sell-config__input"
+              type="number"
+              min={props.min}
+              max={props.max}
+              step="any"
+            />
+            <Show when={field.error}>
+              <span class="buy-sell-config__field-error">{field.error}</span>
+            </Show>
+          </>
+        )}
+      </Field>
+      <span class="buy-sell-config__help">{props.help}</span>
+    </label>
+  );
+}
+
+function ScheduleRowMeta(props: { form: BuySellForm; index: number }) {
   const line = createMemo(() => {
-    const v = getValues(props.form);
-    const row = v[props.kind]?.[props.index];
+    const values = getValues(props.form);
+    const row = values.rows?.[props.index];
     if (!row) return { duration: "—", energy: "—" };
-    const start = String(row.start ?? "");
-    const end = String(row.end ?? "");
-    const hours = rowDurationHours(start, end);
+    const hours = rowDurationHours(String(row.start ?? ""), String(row.end ?? ""));
     if (hours === undefined) return { duration: "—", energy: "—" };
-    const duration = formatDurationLabel(hours);
     const kwh = rowEnergyKwh(Number(row.power), hours);
-    const energy = kwh === undefined ? "—" : `${kwh.toFixed(2)} kWh`;
-    return { duration, energy };
+    return { duration: formatDurationLabel(hours), energy: kwh === undefined ? "—" : `${kwh.toFixed(2)} kWh` };
   });
   return (
     <>
@@ -74,12 +132,28 @@ function ScheduleRowMeta(props: {
   );
 }
 
+/** A row is "planned" when it matches a window of the trader's last plan exactly (any edit makes it yours). */
+function rowIsPlanned(
+  row: { kind?: string; start?: string; end?: string; power?: number },
+  plannedWindows: StateWindow[] | undefined
+): boolean {
+  if (!plannedWindows) return false;
+  return plannedWindows.some(
+    w =>
+      w.kind === row.kind &&
+      isoToDatetimeLocal(w.start) === row.start &&
+      isoToDatetimeLocal(w.end) === row.end &&
+      w.watts === Number(row.power)
+  );
+}
+
 /** Renders only when `getConfig()` is defined. `createForm` runs with server-backed `initialValues` so inputs are filled on first paint (no race with `setValues`). */
 function BuySellFormInner(props: {
   getConfig: Accessor<Config>;
   setConfig: (config: Config) => Promise<boolean | undefined>;
 }) {
-  const [buySellForm, { Form, Field, FieldArray }] = createForm<BuySellFormData>({
+  const [status] = getBackendSyncedSignal<AutoTraderStatus>("autoTraderStatus");
+  const [buySellForm, { Form }] = createForm<BuySellFormData>({
     initialValues: configToBuySellFormData(untrack(() => props.getConfig())),
     validate: zodForm(buySellFormSchema),
     validateOn: "submit",
@@ -91,6 +165,14 @@ function BuySellFormInner(props: {
   // changes (e.g. the auto-trader writing windows) survive a save from an open tab.
   let pristine = configToBuySellFormData(untrack(() => props.getConfig()));
 
+  const resetToServer = () => {
+    const c = props.getConfig();
+    lastAppliedSnap = buySellSliceKey(c);
+    pristine = configToBuySellFormData(c);
+    // reset (not setValues): it also clears the dirty flag, which hides the savebar again
+    reset(buySellForm, { initialValues: pristine });
+  };
+
   createEffect(() => {
     const c = props.getConfig();
     const snap = buySellSliceKey(c);
@@ -99,11 +181,10 @@ function BuySellFormInner(props: {
     // Don't clobber in-progress edits; the diff-merge on save reconciles instead
     if (buySellForm.dirty) return;
     pristine = configToBuySellFormData(c);
-    setValues(buySellForm, pristine, {
-      shouldDirty: false,
-      shouldTouched: false,
-    });
+    setValues(buySellForm, pristine, { shouldDirty: false, shouldTouched: false });
   });
+
+  const plannedWindows = () => status()?.last_plan?.windows;
 
   return (
     <Form
@@ -111,462 +192,322 @@ function BuySellFormInner(props: {
       onSubmit={async values => {
         // modular-forms hands over an empty FieldArray as undefined — normalize before merging
         const raw = values as BuySellFormData;
-        const normalized: BuySellFormData = {
-          ...raw,
-          buyingRows: raw.buyingRows ?? [],
-          sellingRows: raw.sellingRows ?? [],
-        };
+        const normalized: BuySellFormData = { ...raw, rows: raw.rows ?? [] };
         const next = diffMergeFormIntoConfig(pristine, normalized, props.getConfig());
         const ok = await props.setConfig(next);
         const owner = getOwner()!;
         if (ok) {
           await showToastWithMessage(owner, () => "Saved!");
           pristine = configToBuySellFormData(next);
-          setValues(buySellForm, pristine, {
-            shouldDirty: false,
-            shouldTouched: false,
-          });
+          reset(buySellForm, { initialValues: pristine });
           lastAppliedSnap = buySellSliceKey(next);
         }
       }}
     >
-      <div class="buy-sell-config__toolbar">
-        <button
-          type="button"
-          class="buy-sell-config__btn buy-sell-config__btn--secondary"
-          onClick={() => {
-            const c = props.getConfig();
-            lastAppliedSnap = buySellSliceKey(c);
-            pristine = configToBuySellFormData(c);
-            setValues(buySellForm, pristine, {
-              shouldDirty: false,
-              shouldTouched: false,
-            });
-          }}
-        >
-          Reload from server
-        </button>
-        <button type="submit" class="buy-sell-config__btn buy-sell-config__btn--primary">
-          Save
-        </button>
-      </div>
-
-      <Show when={buySellForm.response.status === "error" && buySellForm.response.message}>
-        <p class="buy-sell-config__form-error" role="alert">
-          {buySellForm.response.message}
+      <section class="buy-sell-config__section" aria-labelledby="reserve-heading">
+        <h2 id="reserve-heading">Battery reserve &amp; floors</h2>
+        <p class="buy-sell-config__hint">
+          The ladder the planner works between, from the hard bottom up. Emergency ≤ sunny ≤ planner floor.
         </p>
+        <div class="buy-sell-config__grid2">
+          <NumberField
+            form={buySellForm}
+            name="emergencySocFloor"
+            label="Emergency floor"
+            unit="% SOC"
+            min={0}
+            max={100}
+            help="The hard bottom. Below this the battery is effectively empty and the house pulls from the grid — the planner prices those unavoidable imports."
+          />
+          <NumberField
+            form={buySellForm}
+            name="plannerSocFloor"
+            label="Planner floor"
+            unit="% SOC"
+            min={0}
+            max={100}
+            help="Plans never project SOC below this. Your overnight safety margin against forecast misses."
+          />
+          <NumberField
+            form={buySellForm}
+            name="plannerSocFloorSunny"
+            label="Sunny floor"
+            unit="% SOC"
+            min={0}
+            max={100}
+            help="Relaxed floor used while forecast solar covers the house — a miss then costs minutes of import, not a stranded night."
+          />
+          <NumberField
+            form={buySellForm}
+            name="extraReserveKwh"
+            label="Extra reserve"
+            unit="kWh"
+            min={0}
+            help="Kept on top of the floors when planning, e.g. for charging the car tonight."
+          />
+        </div>
+      </section>
+
+      <section class="buy-sell-config__section" aria-labelledby="guards-heading">
+        <h2 id="guards-heading">Runtime guards</h2>
+        <p class="buy-sell-config__hint">
+          Hard stops the controller enforces while a window runs, regardless of what was planned. Each pair is a
+          hysteresis: stop at one value, resume only past the other.
+        </p>
+        <h3 class="buy-sell-config__subheading">Selling</h3>
+        <div class="buy-sell-config__grid2">
+          <NumberField
+            form={buySellForm}
+            name="sellOnlyAboveSoc"
+            label="Stop selling below"
+            unit="% SOC"
+            min={0}
+            max={100}
+            help="Selling pauses the moment SOC drops under this."
+          />
+          <NumberField
+            form={buySellForm}
+            name="sellStartAgainAboveSoc"
+            label="Resume selling above"
+            unit="% SOC"
+            min={0}
+            max={100}
+            help="…and only resumes once SOC has recovered past this."
+          />
+          <NumberField
+            form={buySellForm}
+            name="onlySellAboveVoltage"
+            label="Stop selling below"
+            unit="V"
+            min={0}
+            help="Voltage sags under load — this catches an empty battery faster than SOC can."
+          />
+          <NumberField
+            form={buySellForm}
+            name="startSellingAgainAboveVoltage"
+            label="Resume selling above"
+            unit="V"
+            min={0}
+            help="Recovery voltage before selling may continue."
+          />
+        </div>
+        <h3 class="buy-sell-config__subheading">Buying</h3>
+        <div class="buy-sell-config__grid2">
+          <NumberField
+            form={buySellForm}
+            name="buyOnlyBelowSoc"
+            label="Stop charging above"
+            unit="% SOC"
+            min={0}
+            max={100}
+            help="Grid charging stops once SOC reaches this."
+          />
+          <NumberField
+            form={buySellForm}
+            name="buyStartAgainBelowSoc"
+            label="Resume charging below"
+            unit="% SOC"
+            min={0}
+            max={100}
+            help="…and only starts again if SOC falls back under this."
+          />
+          <NumberField
+            form={buySellForm}
+            name="maxGridInputAmperage"
+            label="Max grid draw"
+            unit="A"
+            min={0}
+            help="Cap on total grid current while charging — protects the main fuse."
+          />
+        </div>
+      </section>
+
+      <section class="buy-sell-config__section" aria-labelledby="schedule-heading">
+        <h2 id="schedule-heading">Schedule</h2>
+        <p class="buy-sell-config__hint">
+          Everything the controller will do, in order. Rows with a
+          <span class="buy-sell-config__kind-inline">⚡ planned</span>
+          badge were written by the auto-trader — edit or delete them freely: an edited window becomes yours and is
+          planned around; deleting one blocks trading in that time range until unblocked.
+        </p>
+        <FieldArray of={buySellForm} name="rows">
+          {fieldArray => (
+            <>
+              <div class="buy-sell-config__table-wrap">
+                <table class="buy-sell-config__table">
+                  <thead>
+                    <tr>
+                      <th scope="col">What</th>
+                      <th scope="col">Start (local)</th>
+                      <th scope="col">End (local)</th>
+                      <th scope="col">Power (W)</th>
+                      <th scope="col">Duration</th>
+                      <th scope="col">Energy</th>
+                      <th scope="col" class="buy-sell-config__th-actions">
+                        Actions
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <For each={fieldArray.items}>
+                      {(_, index) => (
+                        <tr>
+                          <td class="buy-sell-config__td-kind">
+                            <Field of={buySellForm} name={`rows.${index()}.kind`} type="string">
+                              {(field, p) => (
+                                <>
+                                  <input {...p} type="hidden" value={String(field.value ?? "sell")} />
+                                  <span
+                                    classList={{
+                                      "buy-sell-config__kind": true,
+                                      "buy-sell-config__kind--sell": field.value === "sell",
+                                      "buy-sell-config__kind--buy": field.value === "buy",
+                                    }}
+                                  >
+                                    {field.value === "sell" ? "Sell" : "Buy"}
+                                  </span>
+                                  <Show
+                                    when={rowIsPlanned(getValues(buySellForm).rows?.[index()] ?? {}, plannedWindows())}
+                                  >
+                                    <span
+                                      class="buy-sell-config__planned"
+                                      title="Written by the auto-trader — editing makes it yours"
+                                    >
+                                      ⚡ planned
+                                    </span>
+                                  </Show>
+                                </>
+                              )}
+                            </Field>
+                          </td>
+                          <td class="buy-sell-config__td-datetime">
+                            <Field of={buySellForm} name={`rows.${index()}.start`} type="string">
+                              {(field, p) => (
+                                <>
+                                  <input
+                                    {...p}
+                                    value={fieldValueForInput(field)}
+                                    class="buy-sell-config__input"
+                                    type="datetime-local"
+                                    step={60}
+                                  />
+                                  <Show when={field.error}>
+                                    <span class="buy-sell-config__field-error">{field.error}</span>
+                                  </Show>
+                                </>
+                              )}
+                            </Field>
+                          </td>
+                          <td class="buy-sell-config__td-datetime">
+                            <Field of={buySellForm} name={`rows.${index()}.end`} type="string">
+                              {(field, p) => (
+                                <>
+                                  <input
+                                    {...p}
+                                    value={fieldValueForInput(field)}
+                                    class="buy-sell-config__input"
+                                    type="datetime-local"
+                                    step={60}
+                                  />
+                                  <Show when={field.error}>
+                                    <span class="buy-sell-config__field-error">{field.error}</span>
+                                  </Show>
+                                </>
+                              )}
+                            </Field>
+                          </td>
+                          <td>
+                            <Field of={buySellForm} name={`rows.${index()}.power`} type="number">
+                              {(field, p) => (
+                                <>
+                                  <input
+                                    {...p}
+                                    value={fieldValueForInput(field)}
+                                    class="buy-sell-config__input"
+                                    type="number"
+                                    min={0}
+                                    step="any"
+                                  />
+                                  <Show when={field.error}>
+                                    <span class="buy-sell-config__field-error">{field.error}</span>
+                                  </Show>
+                                </>
+                              )}
+                            </Field>
+                          </td>
+                          <ScheduleRowMeta form={buySellForm} index={index()} />
+                          <td class="buy-sell-config__schedule-actions">
+                            <div class="buy-sell-config__action-btns">
+                              <button
+                                type="button"
+                                class="buy-sell-config__btn buy-sell-config__btn--small"
+                                onClick={() => duplicateScheduleRow(buySellForm, index())}
+                              >
+                                Duplicate
+                              </button>
+                              <button
+                                type="button"
+                                class="buy-sell-config__btn buy-sell-config__btn--small"
+                                onClick={() => remove(buySellForm, "rows", { at: index() })}
+                              >
+                                Remove
+                              </button>
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                    </For>
+                  </tbody>
+                </table>
+              </div>
+              <div class="buy-sell-config__add-btns">
+                <button
+                  type="button"
+                  class="buy-sell-config__btn buy-sell-config__btn--secondary"
+                  onClick={() => insert(buySellForm, "rows", { value: emptyRow("sell", props.getConfig()) })}
+                >
+                  + Sell window
+                </button>
+                <button
+                  type="button"
+                  class="buy-sell-config__btn buy-sell-config__btn--secondary"
+                  onClick={() => insert(buySellForm, "rows", { value: emptyRow("buy", props.getConfig()) })}
+                >
+                  + Buy window
+                </button>
+              </div>
+              <Show when={fieldArray.error}>
+                <p class="buy-sell-config__field-error">{fieldArray.error}</p>
+              </Show>
+            </>
+          )}
+        </FieldArray>
+      </section>
+
+      {/* Appears only while there is something to save — the page's single write path */}
+      <Show when={buySellForm.dirty}>
+        <div class="buy-sell-config__savebar" role="status">
+          <span class="buy-sell-config__savebar-text">
+            Unsaved changes
+            <Show when={buySellForm.response.status === "error" && buySellForm.response.message}>
+              <span class="buy-sell-config__form-error"> — {buySellForm.response.message}</span>
+            </Show>
+          </span>
+          <div class="buy-sell-config__savebar-actions">
+            <button type="button" class="buy-sell-config__btn buy-sell-config__btn--secondary" onClick={resetToServer}>
+              Discard
+            </button>
+            <button type="submit" class="buy-sell-config__btn buy-sell-config__btn--primary">
+              Save
+            </button>
+          </div>
+        </div>
       </Show>
-
-      <section class="buy-sell-config__section" aria-labelledby="buy-sell-buying-heading">
-        <h2 id="buy-sell-buying-heading">Buying from grid</h2>
-        <p class="buy-sell-config__hint">
-          Schedule when to charge from the grid (charging power in watts). Buying only applies when state of charge is
-          below the limits below.
-        </p>
-
-        <div class="buy-sell-config__grid2">
-          <label class="buy-sell-config__label">
-            Only buy below SOC (%)
-            <Field name="buyOnlyBelowSoc" type="number">
-              {(field, p) => (
-                <>
-                  <input
-                    {...p}
-                    value={fieldValueForInput(field)}
-                    class="buy-sell-config__input"
-                    type="number"
-                    min={0}
-                    max={100}
-                    step="any"
-                  />
-                  <Show when={field.error}>
-                    <span class="buy-sell-config__field-error">{field.error}</span>
-                  </Show>
-                </>
-              )}
-            </Field>
-          </label>
-          <label class="buy-sell-config__label">
-            Start buying again below SOC (%)
-            <Field name="buyStartAgainBelowSoc" type="number">
-              {(field, p) => (
-                <>
-                  <input
-                    {...p}
-                    value={fieldValueForInput(field)}
-                    class="buy-sell-config__input"
-                    type="number"
-                    min={0}
-                    max={100}
-                    step="any"
-                  />
-                  <Show when={field.error}>
-                    <span class="buy-sell-config__field-error">{field.error}</span>
-                  </Show>
-                </>
-              )}
-            </Field>
-          </label>
-          <label class="buy-sell-config__label">
-            Max grid input (A)
-            <Field name="maxGridInputAmperage" type="number">
-              {(field, p) => (
-                <>
-                  <input
-                    {...p}
-                    value={fieldValueForInput(field)}
-                    class="buy-sell-config__input"
-                    type="number"
-                    min={0}
-                    step="any"
-                  />
-                  <Show when={field.error}>
-                    <span class="buy-sell-config__field-error">{field.error}</span>
-                  </Show>
-                </>
-              )}
-            </Field>
-          </label>
-        </div>
-
-        <h3 class="buy-sell-config__subheading">Schedule</h3>
-        <p class="buy-sell-config__hint buy-sell-config__hint--schedule">
-          Duration and energy update as you edit. Energy assumes constant charging power for the window: kWh = (watts ×
-          hours) / 1000.
-        </p>
-        <FieldArray name="buyingRows">
-          {fieldArray => (
-            <>
-              <div class="buy-sell-config__table-wrap">
-                <table class="buy-sell-config__table">
-                  <thead>
-                    <tr>
-                      <th scope="col">Start (local)</th>
-                      <th scope="col">End (local)</th>
-                      <th scope="col">Charging power (W)</th>
-                      <th scope="col">Duration</th>
-                      <th scope="col">Energy</th>
-                      <th scope="col" class="buy-sell-config__th-actions">
-                        Actions
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <For each={fieldArray.items}>
-                      {(_, index) => (
-                        <tr>
-                          <td class="buy-sell-config__td-datetime">
-                            <Field name={`buyingRows.${index()}.start`} type="string">
-                              {(field, p) => (
-                                <>
-                                  <input
-                                    {...p}
-                                    value={fieldValueForInput(field)}
-                                    class="buy-sell-config__input"
-                                    type="datetime-local"
-                                    step={60}
-                                  />
-                                  <Show when={field.error}>
-                                    <span class="buy-sell-config__field-error">{field.error}</span>
-                                  </Show>
-                                </>
-                              )}
-                            </Field>
-                          </td>
-                          <td class="buy-sell-config__td-datetime">
-                            <Field name={`buyingRows.${index()}.end`} type="string">
-                              {(field, p) => (
-                                <>
-                                  <input
-                                    {...p}
-                                    value={fieldValueForInput(field)}
-                                    class="buy-sell-config__input"
-                                    type="datetime-local"
-                                    step={60}
-                                  />
-                                  <Show when={field.error}>
-                                    <span class="buy-sell-config__field-error">{field.error}</span>
-                                  </Show>
-                                </>
-                              )}
-                            </Field>
-                          </td>
-                          <td>
-                            <Field name={`buyingRows.${index()}.power`} type="number">
-                              {(field, p) => (
-                                <>
-                                  <input
-                                    {...p}
-                                    value={fieldValueForInput(field)}
-                                    class="buy-sell-config__input"
-                                    type="number"
-                                    min={0}
-                                    step="any"
-                                  />
-                                  <Show when={field.error}>
-                                    <span class="buy-sell-config__field-error">{field.error}</span>
-                                  </Show>
-                                </>
-                              )}
-                            </Field>
-                          </td>
-                          <ScheduleRowMeta form={buySellForm} kind="buyingRows" index={index()} />
-                          <td class="buy-sell-config__schedule-actions">
-                            <div class="buy-sell-config__action-btns">
-                              <button
-                                type="button"
-                                class="buy-sell-config__btn buy-sell-config__btn--small"
-                                onClick={() => duplicateScheduleRow(buySellForm, "buyingRows", index())}
-                              >
-                                Duplicate
-                              </button>
-                              <button
-                                type="button"
-                                class="buy-sell-config__btn buy-sell-config__btn--small"
-                                onClick={() => remove(buySellForm, "buyingRows", { at: index() })}
-                              >
-                                Remove
-                              </button>
-                            </div>
-                          </td>
-                        </tr>
-                      )}
-                    </For>
-                  </tbody>
-                </table>
-              </div>
-              <button
-                type="button"
-                class="buy-sell-config__btn buy-sell-config__btn--secondary"
-                onClick={() => insert(buySellForm, "buyingRows", { value: emptyRow() })}
-              >
-                Add row
-              </button>
-              <Show when={fieldArray.error}>
-                <p class="buy-sell-config__field-error">{fieldArray.error}</p>
-              </Show>
-            </>
-          )}
-        </FieldArray>
-      </section>
-
-      <section class="buy-sell-config__section" aria-labelledby="buy-sell-selling-heading">
-        <h2 id="buy-sell-selling-heading">Selling to grid</h2>
-        <p class="buy-sell-config__hint">
-          Schedule export power (watts). Selling only applies when SOC and battery voltage are above the thresholds
-          below.
-        </p>
-
-        <div class="buy-sell-config__grid2">
-          <label class="buy-sell-config__label">
-            Only sell above SOC (%)
-            <Field name="sellOnlyAboveSoc" type="number">
-              {(field, p) => (
-                <>
-                  <input
-                    {...p}
-                    value={fieldValueForInput(field)}
-                    class="buy-sell-config__input"
-                    type="number"
-                    min={0}
-                    max={100}
-                    step="any"
-                  />
-                  <Show when={field.error}>
-                    <span class="buy-sell-config__field-error">{field.error}</span>
-                  </Show>
-                </>
-              )}
-            </Field>
-          </label>
-          <label class="buy-sell-config__label">
-            Start selling again above SOC (%)
-            <Field name="sellStartAgainAboveSoc" type="number">
-              {(field, p) => (
-                <>
-                  <input
-                    {...p}
-                    value={fieldValueForInput(field)}
-                    class="buy-sell-config__input"
-                    type="number"
-                    min={0}
-                    max={100}
-                    step="any"
-                  />
-                  <Show when={field.error}>
-                    <span class="buy-sell-config__field-error">{field.error}</span>
-                  </Show>
-                </>
-              )}
-            </Field>
-          </label>
-          <label class="buy-sell-config__label">
-            Only sell above voltage (V)
-            <Field name="onlySellAboveVoltage" type="number">
-              {(field, p) => (
-                <>
-                  <input
-                    {...p}
-                    value={fieldValueForInput(field)}
-                    class="buy-sell-config__input"
-                    type="number"
-                    min={0}
-                    step="any"
-                  />
-                  <Show when={field.error}>
-                    <span class="buy-sell-config__field-error">{field.error}</span>
-                  </Show>
-                </>
-              )}
-            </Field>
-          </label>
-          <label class="buy-sell-config__label">
-            Start selling again above voltage (V)
-            <Field name="startSellingAgainAboveVoltage" type="number">
-              {(field, p) => (
-                <>
-                  <input
-                    {...p}
-                    value={fieldValueForInput(field)}
-                    class="buy-sell-config__input"
-                    type="number"
-                    min={0}
-                    step="any"
-                  />
-                  <Show when={field.error}>
-                    <span class="buy-sell-config__field-error">{field.error}</span>
-                  </Show>
-                </>
-              )}
-            </Field>
-          </label>
-        </div>
-
-        <h3 class="buy-sell-config__subheading">Schedule</h3>
-        <p class="buy-sell-config__hint buy-sell-config__hint--schedule">
-          Duration and energy update as you edit. Energy assumes constant export power for the window: kWh = (watts ×
-          hours) / 1000.
-        </p>
-        <FieldArray name="sellingRows">
-          {fieldArray => (
-            <>
-              <div class="buy-sell-config__table-wrap">
-                <table class="buy-sell-config__table">
-                  <thead>
-                    <tr>
-                      <th scope="col">Start (local)</th>
-                      <th scope="col">End (local)</th>
-                      <th scope="col">Export (W)</th>
-                      <th scope="col">Duration</th>
-                      <th scope="col">Energy</th>
-                      <th scope="col" class="buy-sell-config__th-actions">
-                        Actions
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <For each={fieldArray.items}>
-                      {(_, index) => (
-                        <tr>
-                          <td class="buy-sell-config__td-datetime">
-                            <Field name={`sellingRows.${index()}.start`} type="string">
-                              {(field, p) => (
-                                <>
-                                  <input
-                                    {...p}
-                                    value={fieldValueForInput(field)}
-                                    class="buy-sell-config__input"
-                                    type="datetime-local"
-                                    step={60}
-                                  />
-                                  <Show when={field.error}>
-                                    <span class="buy-sell-config__field-error">{field.error}</span>
-                                  </Show>
-                                </>
-                              )}
-                            </Field>
-                          </td>
-                          <td class="buy-sell-config__td-datetime">
-                            <Field name={`sellingRows.${index()}.end`} type="string">
-                              {(field, p) => (
-                                <>
-                                  <input
-                                    {...p}
-                                    value={fieldValueForInput(field)}
-                                    class="buy-sell-config__input"
-                                    type="datetime-local"
-                                    step={60}
-                                  />
-                                  <Show when={field.error}>
-                                    <span class="buy-sell-config__field-error">{field.error}</span>
-                                  </Show>
-                                </>
-                              )}
-                            </Field>
-                          </td>
-                          <td>
-                            <Field name={`sellingRows.${index()}.power`} type="number">
-                              {(field, p) => (
-                                <>
-                                  <input
-                                    {...p}
-                                    value={fieldValueForInput(field)}
-                                    class="buy-sell-config__input"
-                                    type="number"
-                                    min={0}
-                                    step="any"
-                                  />
-                                  <Show when={field.error}>
-                                    <span class="buy-sell-config__field-error">{field.error}</span>
-                                  </Show>
-                                </>
-                              )}
-                            </Field>
-                          </td>
-                          <ScheduleRowMeta form={buySellForm} kind="sellingRows" index={index()} />
-                          <td class="buy-sell-config__schedule-actions">
-                            <div class="buy-sell-config__action-btns">
-                              <button
-                                type="button"
-                                class="buy-sell-config__btn buy-sell-config__btn--small"
-                                onClick={() => duplicateScheduleRow(buySellForm, "sellingRows", index())}
-                              >
-                                Duplicate
-                              </button>
-                              <button
-                                type="button"
-                                class="buy-sell-config__btn buy-sell-config__btn--small"
-                                onClick={() => remove(buySellForm, "sellingRows", { at: index() })}
-                              >
-                                Remove
-                              </button>
-                            </div>
-                          </td>
-                        </tr>
-                      )}
-                    </For>
-                  </tbody>
-                </table>
-              </div>
-              <button
-                type="button"
-                class="buy-sell-config__btn buy-sell-config__btn--secondary"
-                onClick={() => insert(buySellForm, "sellingRows", { value: emptyRow() })}
-              >
-                Add row
-              </button>
-              <Show when={fieldArray.error}>
-                <p class="buy-sell-config__field-error">{fieldArray.error}</p>
-              </Show>
-            </>
-          )}
-        </FieldArray>
-      </section>
     </Form>
   );
 }
 
-export function BuySellConfigForm() {
+export function BuySellConfigForm(): JSX.Element {
   const [config, set_config] = getBackendSyncedSignal<Config>("config", undefined, false);
 
   return (

--- a/frontend/src/components/BuySellConfigForm.tsx
+++ b/frontend/src/components/BuySellConfigForm.tsx
@@ -17,6 +17,7 @@ import { getBackendSyncedSignal } from "~/helpers/getBackendSyncedSignal";
 import { showToastWithMessage } from "~/helpers/showToastWithMessage";
 import {
   configToBuySellFormData,
+  datetimeLocalToIso,
   diffMergeFormIntoConfig,
   isoToDatetimeLocal,
   type BuySellFormData,
@@ -26,7 +27,7 @@ import {
 import { buySellFormSchema } from "~/helpers/buySellFormSchema";
 import { formatDurationLabel, rowDurationHours, rowEnergyKwh } from "~/helpers/scheduleRowDerived";
 import type { Config } from "../../../backend/src/config/config.types";
-import type { AutoTraderStatus, StateWindow } from "../../../backend/src/autoTrading/autoTraderState.types";
+import type { AutoTraderStatus } from "../../../backend/src/autoTrading/autoTraderState.types";
 import "./BuySellConfig.scss";
 
 type BuySellForm = FormStore<BuySellFormData, undefined>;
@@ -132,11 +133,30 @@ function ScheduleRowMeta(props: { form: BuySellForm; index: number }) {
   );
 }
 
-/** A row is "planned" when it matches a window of the trader's last plan exactly (any edit makes it yours). */
-function rowIsPlanned(
-  row: { kind?: string; start?: string; end?: string; power?: number },
-  plannedWindows: StateWindow[] | undefined
-): boolean {
+type FormRowSnapshot = { kind?: string; start?: string; end?: string; power?: number };
+
+/**
+ * A row is "planned" when the trader's ownership record has a value-identical entry for it — the
+ * same rule the backend's reconcileOwnership uses, so an edited row correctly loses its badge.
+ * Older backends don't publish owned_entries yet; fall back to matching the last plan's windows
+ * (a lossy proxy: windows kept through a keepActiveWindows replan are owned but absent there).
+ */
+function rowIsPlanned(row: FormRowSnapshot, status: AutoTraderStatus | undefined): boolean {
+  if (!row.start || !row.end) return false;
+  const owned = status?.owned_entries;
+  if (owned) {
+    const key = datetimeLocalToIso(row.start);
+    if (row.kind === "sell") {
+      const entry = owned.selling[key];
+      return !!entry && isoToDatetimeLocal(entry.end_time) === row.end && entry.power_watts === Number(row.power);
+    }
+    if (row.kind === "buy") {
+      const entry = owned.buying[key];
+      return !!entry && isoToDatetimeLocal(entry.end_time) === row.end && entry.charging_power === Number(row.power);
+    }
+    return false;
+  }
+  const plannedWindows = status?.last_plan?.windows;
   if (!plannedWindows) return false;
   return plannedWindows.some(
     w =>
@@ -183,8 +203,6 @@ function BuySellFormInner(props: {
     pristine = configToBuySellFormData(c);
     setValues(buySellForm, pristine, { shouldDirty: false, shouldTouched: false });
   });
-
-  const plannedWindows = () => status()?.last_plan?.windows;
 
   return (
     <Form
@@ -366,9 +384,7 @@ function BuySellFormInner(props: {
                                   >
                                     {field.value === "sell" ? "Sell" : "Buy"}
                                   </span>
-                                  <Show
-                                    when={rowIsPlanned(getValues(buySellForm).rows?.[index()] ?? {}, plannedWindows())}
-                                  >
+                                  <Show when={rowIsPlanned(getValues(buySellForm).rows?.[index()] ?? {}, status())}>
                                     <span
                                       class="buy-sell-config__planned"
                                       title="Written by the auto-trader — editing makes it yours"

--- a/frontend/src/helpers/buySellConfigMapping.ts
+++ b/frontend/src/helpers/buySellConfigMapping.ts
@@ -1,12 +1,21 @@
 import type { Config } from "../../../backend/src/config/config.types";
 
+export type ScheduleRowKind = "sell" | "buy";
+
 export type BuySellScheduleRow = {
+  kind: ScheduleRowKind;
   start: string;
   end: string;
   power: number;
 };
 
 export type BuySellFormData = {
+  // Battery reserve & floors (automatic_trading)
+  emergencySocFloor: number;
+  plannerSocFloor: number;
+  plannerSocFloorSunny: number;
+  extraReserveKwh: number;
+  // Runtime guards
   buyOnlyBelowSoc: number;
   buyStartAgainBelowSoc: number;
   maxGridInputAmperage: number;
@@ -14,8 +23,8 @@ export type BuySellFormData = {
   sellStartAgainAboveSoc: number;
   onlySellAboveVoltage: number;
   startSellingAgainAboveVoltage: number;
-  buyingRows: BuySellScheduleRow[];
-  sellingRows: BuySellScheduleRow[];
+  /** One chronological list; kind decides which config schedule a row lands in */
+  rows: BuySellScheduleRow[];
 };
 
 /** Display ISO datetimes in `datetime-local` format (local wall time). */
@@ -32,24 +41,26 @@ export function datetimeLocalToIso(local: string): string {
   return d.toISOString();
 }
 
-function scheduleToBuyingRows(schedule: Config["scheduled_power_buying"]["schedule"]): BuySellScheduleRow[] {
-  return Object.entries(schedule).map(([start, v]) => ({
-    start: isoToDatetimeLocal(start),
-    end: isoToDatetimeLocal(v.end_time),
-    power: v.charging_power,
-  }));
-}
-
-function scheduleToSellingRows(schedule: Config["scheduled_power_selling"]["schedule"]): BuySellScheduleRow[] {
-  return Object.entries(schedule).map(([start, v]) => ({
-    start: isoToDatetimeLocal(start),
-    end: isoToDatetimeLocal(v.end_time),
-    power: v.power_watts,
-  }));
-}
-
 export function configToBuySellFormData(c: Config): BuySellFormData {
+  const rows: BuySellScheduleRow[] = [
+    ...Object.entries(c.scheduled_power_selling.schedule).map(([start, v]) => ({
+      kind: "sell" as const,
+      start: isoToDatetimeLocal(start),
+      end: isoToDatetimeLocal(v.end_time),
+      power: v.power_watts,
+    })),
+    ...Object.entries(c.scheduled_power_buying.schedule).map(([start, v]) => ({
+      kind: "buy" as const,
+      start: isoToDatetimeLocal(start),
+      end: isoToDatetimeLocal(v.end_time),
+      power: v.charging_power,
+    })),
+  ].sort((a, b) => a.start.localeCompare(b.start));
   return {
+    emergencySocFloor: c.automatic_trading.emergency_soc_floor_percent,
+    plannerSocFloor: c.automatic_trading.planner_soc_floor_percent,
+    plannerSocFloorSunny: c.automatic_trading.planner_soc_floor_sunny_percent,
+    extraReserveKwh: c.automatic_trading.extra_reserve_kwh,
     buyOnlyBelowSoc: c.scheduled_power_buying.only_buy_below_soc,
     buyStartAgainBelowSoc: c.scheduled_power_buying.start_buying_again_below_soc,
     maxGridInputAmperage: c.scheduled_power_buying.max_grid_input_amperage,
@@ -57,8 +68,7 @@ export function configToBuySellFormData(c: Config): BuySellFormData {
     sellStartAgainAboveSoc: c.scheduled_power_selling.start_selling_again_above_soc,
     onlySellAboveVoltage: c.scheduled_power_selling.only_sell_above_voltage,
     startSellingAgainAboveVoltage: c.scheduled_power_selling.start_selling_again_above_voltage,
-    buyingRows: scheduleToBuyingRows(c.scheduled_power_buying.schedule),
-    sellingRows: scheduleToSellingRows(c.scheduled_power_selling.schedule),
+    rows,
   };
 }
 
@@ -71,21 +81,21 @@ export function filterCompleteRows(rows: BuySellScheduleRow[]): BuySellScheduleR
  * Three-way merge: apply only what the user actually changed (vs the `pristine` snapshot the form
  * was loaded from) onto the latest server config. Rows/fields the user never touched keep whatever
  * the server has now — so a schedule the auto-trader wrote while the tab was open survives a save.
- * Row identity is the start time: editing a row's start counts as delete-old + add-new.
+ * Row identity is kind + start time: editing either counts as delete-old + add-new.
  */
 export function diffMergeFormIntoConfig(pristine: BuySellFormData, values: BuySellFormData, latest: Config): Config {
   const scalar = (before: number, now: number, latestVal: number): number =>
     Number(now) !== Number(before) ? Number(now) : latestVal;
 
   const mergeSchedule = <E extends { end_time: string }>(
-    pristineRows: BuySellScheduleRow[],
-    currentRows: BuySellScheduleRow[],
+    kind: ScheduleRowKind,
     latestSchedule: Record<string, E>,
     toEntry: (row: BuySellScheduleRow) => E
   ): Record<string, E> => {
+    const ofKind = (rows: BuySellScheduleRow[]) => filterCompleteRows(rows).filter(r => r.kind === kind);
     const result: Record<string, E> = { ...latestSchedule };
-    const pristineByKey = new Map(filterCompleteRows(pristineRows).map(r => [datetimeLocalToIso(r.start), r]));
-    const currentByKey = new Map(filterCompleteRows(currentRows).map(r => [datetimeLocalToIso(r.start), r]));
+    const pristineByKey = new Map(ofKind(pristine.rows).map(r => [datetimeLocalToIso(r.start), r]));
+    const currentByKey = new Map(ofKind(values.rows).map(r => [datetimeLocalToIso(r.start), r]));
     for (const key of pristineByKey.keys()) {
       if (!currentByKey.has(key)) delete result[key]; // the user removed this row
     }
@@ -99,6 +109,29 @@ export function diffMergeFormIntoConfig(pristine: BuySellFormData, values: BuySe
 
   return {
     ...latest,
+    automatic_trading: {
+      ...latest.automatic_trading,
+      emergency_soc_floor_percent: scalar(
+        pristine.emergencySocFloor,
+        values.emergencySocFloor,
+        latest.automatic_trading.emergency_soc_floor_percent
+      ),
+      planner_soc_floor_percent: scalar(
+        pristine.plannerSocFloor,
+        values.plannerSocFloor,
+        latest.automatic_trading.planner_soc_floor_percent
+      ),
+      planner_soc_floor_sunny_percent: scalar(
+        pristine.plannerSocFloorSunny,
+        values.plannerSocFloorSunny,
+        latest.automatic_trading.planner_soc_floor_sunny_percent
+      ),
+      extra_reserve_kwh: scalar(
+        pristine.extraReserveKwh,
+        values.extraReserveKwh,
+        latest.automatic_trading.extra_reserve_kwh
+      ),
+    },
     scheduled_power_buying: {
       only_buy_below_soc: scalar(
         pristine.buyOnlyBelowSoc,
@@ -115,7 +148,7 @@ export function diffMergeFormIntoConfig(pristine: BuySellFormData, values: BuySe
         values.maxGridInputAmperage,
         latest.scheduled_power_buying.max_grid_input_amperage
       ),
-      schedule: mergeSchedule(pristine.buyingRows, values.buyingRows, latest.scheduled_power_buying.schedule, row => ({
+      schedule: mergeSchedule("buy", latest.scheduled_power_buying.schedule, row => ({
         end_time: datetimeLocalToIso(row.end),
         charging_power: Number(row.power),
       })),
@@ -141,15 +174,10 @@ export function diffMergeFormIntoConfig(pristine: BuySellFormData, values: BuySe
         values.startSellingAgainAboveVoltage,
         latest.scheduled_power_selling.start_selling_again_above_voltage
       ),
-      schedule: mergeSchedule(
-        pristine.sellingRows,
-        values.sellingRows,
-        latest.scheduled_power_selling.schedule,
-        row => ({
-          end_time: datetimeLocalToIso(row.end),
-          power_watts: Number(row.power),
-        })
-      ),
+      schedule: mergeSchedule("sell", latest.scheduled_power_selling.schedule, row => ({
+        end_time: datetimeLocalToIso(row.end),
+        power_watts: Number(row.power),
+      })),
     },
   };
 }

--- a/frontend/src/helpers/buySellFormSchema.ts
+++ b/frontend/src/helpers/buySellFormSchema.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { datetimeLocalToIso, type BuySellFormData } from "./buySellConfigMapping";
 
 const scheduleRowSchema = z.object({
+  kind: z.enum(["sell", "buy"]),
   start: z.string(),
   end: z.string(),
   power: z.coerce.number(),
@@ -9,57 +10,104 @@ const scheduleRowSchema = z.object({
 
 export const buySellFormSchema = z
   .object({
-    buyOnlyBelowSoc: z.coerce.number(),
-    buyStartAgainBelowSoc: z.coerce.number(),
-    maxGridInputAmperage: z.coerce.number(),
-    sellOnlyAboveSoc: z.coerce.number(),
-    sellStartAgainAboveSoc: z.coerce.number(),
-    onlySellAboveVoltage: z.coerce.number(),
-    startSellingAgainAboveVoltage: z.coerce.number(),
+    emergencySocFloor: z.coerce.number().min(0).max(100),
+    plannerSocFloor: z.coerce.number().min(0).max(100),
+    plannerSocFloorSunny: z.coerce.number().min(0).max(100),
+    extraReserveKwh: z.coerce.number().min(0),
+    // Runtime SOC thresholds deliberately allow >100: setting a buy threshold to 101 means
+    // "charge unconditionally" (and a sell cutoff >100 means "never sell") — both in live use.
+    buyOnlyBelowSoc: z.coerce.number().min(0),
+    buyStartAgainBelowSoc: z.coerce.number().min(0),
+    maxGridInputAmperage: z.coerce.number().min(0),
+    sellOnlyAboveSoc: z.coerce.number().min(0),
+    sellStartAgainAboveSoc: z.coerce.number().min(0),
+    onlySellAboveVoltage: z.coerce.number().min(0),
+    startSellingAgainAboveVoltage: z.coerce.number().min(0),
     // .default([]): modular-forms materializes an EMPTY FieldArray as undefined, and a bare
     // z.array() then fails with "Required" — which made the whole form unsavable whenever the
-    // buy schedule had no rows (e.g. after old buy windows were pruned).
-    buyingRows: z.array(scheduleRowSchema).default([]),
-    sellingRows: z.array(scheduleRowSchema).default([]),
+    // schedule had no rows (e.g. after old windows were pruned).
+    rows: z.array(scheduleRowSchema).default([]),
   })
   .superRefine((data, ctx) => {
-    const checkRows = (rows: BuySellFormData["buyingRows"], path: "buyingRows" | "sellingRows") => {
+    // The floors form a ladder (see AutomaticTradingConfig comments): the relaxed sunny floor may
+    // never exceed the normal planner floor, the emergency bottom sits under both, and the
+    // runtime sell cutoff must stay at or below the sunny floor or the planner would promise
+    // energy the runtime refuses to deliver.
+    if (data.plannerSocFloorSunny > data.plannerSocFloor) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["plannerSocFloorSunny"],
+        message: "Sunny floor must be ≤ the planner floor",
+      });
+    }
+    if (data.emergencySocFloor > data.plannerSocFloorSunny) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["emergencySocFloor"],
+        message: "Emergency floor must be ≤ the sunny floor",
+      });
+    }
+    // (No hard rule tying the sell cutoff to the sunny floor: the config comment recommends
+    // cutoff ≤ sunny floor, but the live systems run other arrangements on purpose.)
+    // Hysteresis pairs must not invert
+    if (data.sellStartAgainAboveSoc < data.sellOnlyAboveSoc) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["sellStartAgainAboveSoc"],
+        message: "Resume threshold must be ≥ the stop threshold",
+      });
+    }
+    if (data.startSellingAgainAboveVoltage < data.onlySellAboveVoltage) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["startSellingAgainAboveVoltage"],
+        message: "Resume voltage must be ≥ the stop voltage",
+      });
+    }
+    if (data.buyStartAgainBelowSoc > data.buyOnlyBelowSoc) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["buyStartAgainBelowSoc"],
+        message: "Resume threshold must be ≤ the stop threshold",
+      });
+    }
+
+    const checkRows = (kind: "sell" | "buy") => {
       const seen = new Set<string>();
-      rows.forEach((row, i) => {
-        if (row.start.trim() === "" || row.end.trim() === "") return;
+      data.rows.forEach((row, i) => {
+        if (row.kind !== kind || row.start.trim() === "" || row.end.trim() === "") return;
         const k = datetimeLocalToIso(row.start);
         if (seen.has(k)) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
-            path: [path, i, "start"],
-            message: "Duplicate start time in this list",
+            path: ["rows", i, "start"],
+            message: "Duplicate start time for this kind",
           });
         }
         seen.add(k);
       });
-
-      rows.forEach((row, i) => {
-        const hasAny = row.start.trim() !== "" || row.end.trim() !== "";
-        const hasAll = row.start.trim() !== "" && row.end.trim() !== "";
-        if (hasAny && !hasAll) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: [path, i, "start"],
-            message: "Set both start and end, or clear the row",
-          });
-        }
-        if (hasAll) {
-          if (new Date(row.end) <= new Date(row.start)) {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              path: [path, i, "end"],
-              message: "End must be after start",
-            });
-          }
-        }
-      });
     };
+    checkRows("sell");
+    checkRows("buy");
 
-    checkRows(data.buyingRows, "buyingRows");
-    checkRows(data.sellingRows, "sellingRows");
+    data.rows.forEach((row, i) => {
+      const hasAny = row.start.trim() !== "" || row.end.trim() !== "";
+      const hasAll = row.start.trim() !== "" && row.end.trim() !== "";
+      if (hasAny && !hasAll) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["rows", i, "start"],
+          message: "Set both start and end, or clear the row",
+        });
+      }
+      if (hasAll && new Date(row.end) <= new Date(row.start)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["rows", i, "end"],
+          message: "End must be after start",
+        });
+      }
+    });
   });
+
+export type ParsedBuySellForm = BuySellFormData;

--- a/frontend/src/helpers/buySellFormSchema.ts
+++ b/frontend/src/helpers/buySellFormSchema.ts
@@ -49,8 +49,11 @@ export const buySellFormSchema = z
     }
     // (No hard rule tying the sell cutoff to the sunny floor: the config comment recommends
     // cutoff ≤ sunny floor, but the live systems run other arrangements on purpose.)
-    // Hysteresis pairs must not invert
-    if (data.sellStartAgainAboveSoc < data.sellOnlyAboveSoc) {
+    // Hysteresis pairs must not invert. The sell check is skipped when the stop threshold is the
+    // >100 "never sell" sentinel — resume is necessarily below it then, and erroring would make
+    // the whole form unsavable (the same lockout class this schema was reworked to avoid). The
+    // buy direction needs no guard: its sentinel is high (e.g. 200) and its rule checks ≤.
+    if (data.sellOnlyAboveSoc <= 100 && data.sellStartAgainAboveSoc < data.sellOnlyAboveSoc) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["sellStartAgainAboveSoc"],


### PR DESCRIPTION
Stacked on #37. Per-item review from the page-design discussion:

- **One interaction model**: every value edit stages into a sticky Save/Discard bar that exists only while the form is dirty; buttons that *do* things (enable, generate, unblock) stay immediate. "Reload from server" is gone — a clean form auto-syncs anyway, so its only real function (discard my edits) now lives where it makes sense.
- **Battery reserve & floors** section: emergency / planner / sunny floors + extra reserve, each with a plain-language explanation, cross-validated as a ladder (emergency ≤ sunny ≤ planner). Extra reserve moved here from the auto-trader panel.
- **Runtime guards** section: the hysteresis pairs explained; SOC thresholds deliberately allow >100 because the live configs use 101 as "charge unconditionally" (found by the form refusing to validate the running system 😄).
- **Unified schedule**: one chronological table, Sell/Buy chips, "⚡ planned" badge on rows still matching the trader's last plan (any edit makes a row yours), add-buttons prefill the next full hour at kind-appropriate power. Diff-merge save semantics preserved per kind and extended to the automatic_trading scalars.

Tested end-to-end against the live pi: dirty→Discard restores and hides the bar, dirty→Save round-trips config (verified value on the pi and restored), cross-field validation errors render inline at the offending fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAZ1X2Zdh7MXiQc7m6VXiu