### PR TITLE
Typed ws contract between backend and frontend

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -18,7 +18,7 @@ import { saveTemperatures } from "./temperatureMeasuring/saveTemperatures.ts";
 import { feedWhenNoSolar } from "./feeding/feedWhenNoSolar.ts";
 import { useBatteryValues } from "./battery/useBatteryValues.ts";
 import { BatteryValuesProvider } from "./battery/BatteryValuesProvider.ts";
-import { mqttValueKeys } from "./sharedTypes.ts";
+import { mqttValueKeys, type MqttValue, type MqttValueKey } from "./sharedTypes.ts";
 import { elpatronSwitching } from "./elpatronSwitching.ts";
 import { shouldSellPower } from "./feeding/shouldSellPower.ts";
 import { NowProvider } from "./utilities/useNow.ts";
@@ -302,8 +302,16 @@ function main() {
                           assumedParasiticConsumption,
                           isCharging: () => isChargingOuterScope()?.()?.(),
                           elpatronState: () => elpatronReturn()?.elpatronHeating(),
-                          totalLastFull: () => totalLastFull() && new Date(totalLastFull()!).toISOString(),
-                          ...Object.fromEntries(mqttValueKeys.map(key => [key, () => mqttValues[key]])),
+                          // (the old `&& ...toISOString()` here could leak a raw 0 onto the wire)
+                          totalLastFull: () => {
+                            const lastFullMs = totalLastFull();
+                            return lastFullMs ? new Date(lastFullMs).toISOString() : undefined;
+                          },
+                          // Object.fromEntries can't carry the per-key mapping — the cast restores
+                          // what is provably true from mqttValueKeys.map
+                          ...(Object.fromEntries(mqttValueKeys.map(key => [key, () => mqttValues[key]])) as {
+                            [K in MqttValueKey]: () => MqttValue | undefined;
+                          }),
                         },
                       })
                     );

--- a/backend/src/sharedTypes.ts
+++ b/backend/src/sharedTypes.ts
@@ -21,6 +21,8 @@ export function resolveElpatronMode(elpatronConfig: { mode?: ElpatronMode; enabl
   return elpatronConfig.mode ?? (elpatronConfig.enabled ? "solar" : "off");
 }
 
+export type MqttValueKey = (typeof mqttValueKeys)[number];
+
 export const mqttValueKeys = [
   "solar_input_power_1",
   "solar_input_power_2",

--- a/backend/src/websocketBackend/wsMessaging.ts
+++ b/backend/src/websocketBackend/wsMessaging.ts
@@ -3,6 +3,7 @@ import { startWsServer } from "./startWsServer.ts";
 import { useTemperatures } from "../temperatureMeasuring/useTemperatures.ts";
 import type { Config } from "../config/config.types.ts";
 import type { TemperatureReadingBroadcast } from "../sharedTypes.ts";
+import type { WsAction, WsExposedAccessorMap } from "../wsContract.types.ts";
 
 export async function wsMessaging({
   config_signal: [get_config, set_config],
@@ -14,8 +15,9 @@ export async function wsMessaging({
   config_signal: Signal<Config>;
   owner: Owner;
   temperatures: ReturnType<typeof useTemperatures>;
-  exposedAccessors: Record<string, Accessor<any>>;
-  actions: Record<string, () => Promise<string>>;
+  /** Typed by the ws contract — exposing a key with the wrong shape (or forgetting one) won't compile */
+  exposedAccessors: WsExposedAccessorMap;
+  actions: Record<WsAction, () => Promise<string>>;
 }) {
   const exposed_signals = {
     config: {
@@ -37,7 +39,8 @@ export async function wsMessaging({
     const { command, key, value, id, action } = msg;
 
     if (command === "action") {
-      const handler = actions[action as string];
+      // action arrives as untrusted wire input — the runtime unknown-action reply below handles misses
+      const handler = (actions as Partial<Record<string, () => Promise<string>>>)[String(action)];
       if (!handler) {
         return JSON.stringify({
           id,
@@ -99,6 +102,12 @@ export async function wsMessaging({
 
 function serializeTemperatures(
   temperatures: ReturnType<typeof useTemperatures>
-): Record<string, TemperatureReadingBroadcast | undefined> {
-  return Object.fromEntries(Object.entries(temperatures()).map(([device_id, value]) => [device_id, value()]));
+): Record<string, TemperatureReadingBroadcast> {
+  // Thermometers without a reading yet are omitted (JSON.stringify would drop the undefineds
+  // on the wire anyway — filtering makes the contract type honest)
+  return Object.fromEntries(
+    Object.entries(temperatures())
+      .map(([device_id, value]) => [device_id, value()] as const)
+      .filter((entry): entry is readonly [string, TemperatureReadingBroadcast] => entry[1] !== undefined)
+  );
 }

--- a/backend/src/wsContract.types.ts
+++ b/backend/src/wsContract.types.ts
@@ -1,0 +1,73 @@
+import type { Config } from "./config/config.types.ts";
+import type { AutoTraderStatus } from "./autoTrading/autoTraderState.types.ts";
+import type { FetchedPrices } from "./autoTrading/priceService.types.ts";
+import type { AlertRecord } from "./alerting/alerting.types.ts";
+import type {
+  CurrentBatteryPowerBroadcast,
+  ElpatronDisplayState,
+  MqttValue,
+  MqttValueKey,
+  TemperatureReadingBroadcast,
+} from "./sharedTypes.ts";
+
+/**
+ * THE ws wire contract: every key the backend exposes mapped to the value it carries. Both sides
+ * derive from this one map — wsMessaging types its accessor/action parameters with it (so the
+ * backend cannot expose a mismatch) and the frontend's getBackendSyncedSignal infers its value
+ * type from the key (so a typo'd key or a wrongly assumed shape is a compile error, not a runtime
+ * surprise). Values are the PRESENT types; "hasn't arrived yet" undefined is added by the signal
+ * layer. Pure types only — the frontend imports this file directly.
+ */
+export type WsExposedSignals = {
+  /** The whole runtime config; the only writable key */
+  config: Config;
+  temperatures: Record<string, TemperatureReadingBroadcast>;
+  autoTraderStatus: AutoTraderStatus;
+  spotPrices: FetchedPrices;
+  recentAlerts: AlertRecord[];
+  elpatronState: ElpatronDisplayState;
+  currentBatteryPower: CurrentBatteryPowerBroadcast;
+  /** Clamped to [0,100] — the SOC the trading logic runs on */
+  averageSOC: number;
+  /** Shadow Ah ledger, unclamped — diagnostics only */
+  socAh: number;
+  socSinceEmpty: number;
+  socSinceFull: number;
+  /** Wh */
+  assumedCapacity: number;
+  /** W */
+  assumedParasiticConsumption: number;
+  /** Wh until full again */
+  energyRemovedSinceFull: number;
+  /** Wh until empty again */
+  energyAddedSinceEmpty: number;
+  /** ISO timestamp */
+  totalLastFull: string;
+  /** ms epoch */
+  totalLastEmpty: number;
+  isCharging: boolean;
+  lastFeedWhenNoSolarReason: { what: string; when: number };
+  lastChangingFeedWhenNoSolarReason: { what: string; when: number };
+  /** Hall sensor 1, raw millivolts */
+  voltageSagMillivoltsRaw: { value: number; time: number };
+  voltageSagMillivoltsAveraged: number;
+  /** Hall sensor 2 (positive pole) */
+  voltageSagMillivoltsRaw2: { value: number; time: number };
+  voltageSagMillivoltsAveraged2: number;
+} & { [K in MqttValueKey]: MqttValue };
+
+export type WsSignalKey = keyof WsExposedSignals;
+
+/** Keys the frontend may write; everything else is read-only over the ws. */
+export type WsWritableSignalKey = "config";
+
+export type WsAction = "generate_trading_plan" | "clear_trading_vetoes" | "send_test_alert";
+
+/**
+ * What index.ts must hand wsMessaging: an accessor per contract key, except `config` and
+ * `temperatures`, which wsMessaging wires itself. Accessors may yield undefined before their
+ * subsystem has produced a value.
+ */
+export type WsExposedAccessorMap = {
+  [K in Exclude<WsSignalKey, "config" | "temperatures">]: () => WsExposedSignals[K] | undefined;
+};

--- a/frontend/src/components/AutoTraderPanel.tsx
+++ b/frontend/src/components/AutoTraderPanel.tsx
@@ -4,13 +4,13 @@ import { showToastWithMessage } from "~/helpers/showToastWithMessage";
 import { useWebSocket } from "~/components/WebSocketProvider";
 import { formatKwh, formatSek, formatShortDateTime } from "~/helpers/format";
 import type { Config } from "../../../backend/src/config/config.types";
-import type { AutoTraderStatus } from "../../../backend/src/autoTrading/autoTraderState.types";
+import type { WsAction } from "../../../backend/src/wsContract.types";
 
 const fmtTime = (iso: string | undefined) => (iso ? formatShortDateTime(iso) : "—");
 
 export function AutoTraderPanel() {
-  const [status] = getBackendSyncedSignal<AutoTraderStatus>("autoTraderStatus");
-  const [config, setConfig] = getBackendSyncedSignal<Config>("config");
+  const [status] = getBackendSyncedSignal("autoTraderStatus");
+  const [config, setConfig] = getBackendSyncedSignal("config");
   const socket = useWebSocket();
   const owner = getOwner()!;
   const [busy, setBusy] = createSignal(false);
@@ -26,7 +26,7 @@ export function AutoTraderPanel() {
     await setConfig({ ...current, automatic_trading: { ...current.automatic_trading, ...patch } });
   };
 
-  const runAction = async (action: string, formatResult: (result: string) => string) => {
+  const runAction = async (action: WsAction, formatResult: (result: string) => string) => {
     setBusy(true);
     try {
       const result = await sendBackendAction(socket, action);

--- a/frontend/src/components/BuySellConfigForm.tsx
+++ b/frontend/src/components/BuySellConfigForm.tsx
@@ -172,7 +172,7 @@ function BuySellFormInner(props: {
   getConfig: Accessor<Config>;
   setConfig: (config: Config) => Promise<boolean | undefined>;
 }) {
-  const [status] = getBackendSyncedSignal<AutoTraderStatus>("autoTraderStatus");
+  const [status] = getBackendSyncedSignal("autoTraderStatus");
   const [buySellForm, { Form }] = createForm<BuySellFormData>({
     initialValues: configToBuySellFormData(untrack(() => props.getConfig())),
     validate: zodForm(buySellFormSchema),
@@ -524,7 +524,7 @@ function BuySellFormInner(props: {
 }
 
 export function BuySellConfigForm(): JSX.Element {
-  const [config, set_config] = getBackendSyncedSignal<Config>("config", undefined, false);
+  const [config, set_config] = getBackendSyncedSignal("config", undefined, false);
 
   return (
     <Show when={config()} fallback={<p class="buy-sell-config__loading">Loading configuration…</p>}>

--- a/frontend/src/components/ConfigEditor.tsx
+++ b/frontend/src/components/ConfigEditor.tsx
@@ -2,13 +2,12 @@ import { createComputed, getOwner } from "solid-js";
 import "./ConfigEditor.scss";
 import { getBackendSyncedSignal } from "~/helpers/getBackendSyncedSignal";
 import { showToastWithMessage } from "~/helpers/showToastWithMessage";
+import type { Config } from "../../../backend/src/config/config.types";
 
 export function ConfigEditor() {
   let textarea: HTMLTextAreaElement;
   let button: HTMLButtonElement | undefined;
-  const [get_config, set_config] = getBackendSyncedSignal<{
-    [key: string]: any;
-  }>("config", undefined, false);
+  const [get_config, set_config] = getBackendSyncedSignal("config", undefined, false);
   const owner = getOwner()!;
 
   return (
@@ -34,9 +33,10 @@ export function ConfigEditor() {
           if (!set_config) {
             return;
           }
-          let object_contents: { [key: string]: any } | undefined;
+          let object_contents: Config | undefined;
           try {
-            object_contents = JSON.parse(textarea.value);
+            // The raw-JSON escape hatch can't prove the shape — the backend validates on write
+            object_contents = JSON.parse(textarea.value) as Config;
           } catch (e) {
             console.error(e);
             await showToastWithMessage(owner, () => "Error parsing JSON: " + e);

--- a/frontend/src/components/PricePlanChart.tsx
+++ b/frontend/src/components/PricePlanChart.tsx
@@ -32,9 +32,9 @@ const PLOT_H = VIEW_H - PAD_T - PAD_B;
  * truth for what will run); min-SOC and the price series need the trading-aware backend.
  */
 export function PricePlanChart() {
-  const [spotPrices] = getBackendSyncedSignal<FetchedPrices>("spotPrices", undefined, true, true);
-  const [config] = getBackendSyncedSignal<Config>("config", undefined, false);
-  const [status] = getBackendSyncedSignal<AutoTraderStatus>("autoTraderStatus");
+  const [spotPrices] = getBackendSyncedSignal("spotPrices", undefined, true, true);
+  const [config] = getBackendSyncedSignal("config", undefined, false);
+  const [status] = getBackendSyncedSignal("autoTraderStatus");
   const now = useNowMs(30_000);
   const [hoverIndex, setHoverIndex] = createSignal<number>();
   let svgElement: SVGSVGElement | undefined;

--- a/frontend/src/components/dashboard/BatteryCard.tsx
+++ b/frontend/src/components/dashboard/BatteryCard.tsx
@@ -18,14 +18,14 @@ const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
 export function BatteryCard() {
   // averageSOC is the clamped SOC the trading logic actually runs on — the number that was
   // broadcast all along but shown nowhere before this card existed.
-  const [averageSOC] = getBackendSyncedSignal<number>("averageSOC");
-  const [assumedCapacity] = getBackendSyncedSignal<number>("assumedCapacity");
-  const [currentBatteryPower] = getBackendSyncedSignal<CurrentBatteryPowerBroadcast>("currentBatteryPower");
-  const [assumedParasiticConsumption] = getBackendSyncedSignal<number>("assumedParasiticConsumption");
-  const [energyRemovedSinceFull] = getBackendSyncedSignal<number>("energyRemovedSinceFull");
-  const [energyAddedSinceEmpty] = getBackendSyncedSignal<number>("energyAddedSinceEmpty");
-  const [totalLastFull] = getBackendSyncedSignal<string>("totalLastFull");
-  const [totalLastEmpty] = getBackendSyncedSignal<number>("totalLastEmpty");
+  const [averageSOC] = getBackendSyncedSignal("averageSOC");
+  const [assumedCapacity] = getBackendSyncedSignal("assumedCapacity");
+  const [currentBatteryPower] = getBackendSyncedSignal("currentBatteryPower");
+  const [assumedParasiticConsumption] = getBackendSyncedSignal("assumedParasiticConsumption");
+  const [energyRemovedSinceFull] = getBackendSyncedSignal("energyRemovedSinceFull");
+  const [energyAddedSinceEmpty] = getBackendSyncedSignal("energyAddedSinceEmpty");
+  const [totalLastFull] = getBackendSyncedSignal("totalLastFull");
+  const [totalLastEmpty] = getBackendSyncedSignal("totalLastEmpty");
   const now = useNowMs(1000);
 
   const activity = useBatteryActivity({

--- a/frontend/src/components/dashboard/NextUpCard.tsx
+++ b/frontend/src/components/dashboard/NextUpCard.tsx
@@ -24,8 +24,8 @@ function settlementDayLabel(settledDate: string, nowMs: number): string {
 }
 
 export function NextUpCard() {
-  const [status] = getBackendSyncedSignal<AutoTraderStatus>("autoTraderStatus");
-  const [config] = getBackendSyncedSignal<Config>("config", undefined, false);
+  const [status] = getBackendSyncedSignal("autoTraderStatus");
+  const [config] = getBackendSyncedSignal("config", undefined, false);
   const now = useNowMs(30_000);
 
   // Windows from the config schedules (what will actually run), enriched with the planner's

--- a/frontend/src/components/dashboard/PowerFlowCard.tsx
+++ b/frontend/src/components/dashboard/PowerFlowCard.tsx
@@ -18,11 +18,11 @@ const BALANCE_TOLERANCE_WATTS = 500;
  * sums for its sanity check; the card-meta shows that balance so a broken sensor is visible here too.
  */
 export function PowerFlowCard() {
-  const [solar_input_power_1] = getBackendSyncedSignal<MqttValue>("solar_input_power_1");
-  const [solar_input_power_2] = getBackendSyncedSignal<MqttValue>("solar_input_power_2");
-  const [ac_output_total_active_power] = getBackendSyncedSignal<MqttValue>("ac_output_total_active_power");
-  const [ac_input_total_active_power] = getBackendSyncedSignal<MqttValue>("ac_input_total_active_power");
-  const [currentBatteryPower] = getBackendSyncedSignal<CurrentBatteryPowerBroadcast>("currentBatteryPower");
+  const [solar_input_power_1] = getBackendSyncedSignal("solar_input_power_1");
+  const [solar_input_power_2] = getBackendSyncedSignal("solar_input_power_2");
+  const [ac_output_total_active_power] = getBackendSyncedSignal("ac_output_total_active_power");
+  const [ac_input_total_active_power] = getBackendSyncedSignal("ac_input_total_active_power");
+  const [currentBatteryPower] = getBackendSyncedSignal("currentBatteryPower");
 
   const solarWatts = createMemo(() => {
     const array1 = solar_input_power_1()?.value;

--- a/frontend/src/components/dashboard/TemperatureChips.tsx
+++ b/frontend/src/components/dashboard/TemperatureChips.tsx
@@ -9,7 +9,7 @@ import type { TemperatureReadingBroadcast } from "../../../../backend/src/shared
 const STALE_AFTER_MS = 3 * 60_000;
 
 export function TemperatureChips() {
-  const [temperatures] = getBackendSyncedSignal<Record<string, TemperatureReadingBroadcast>>("temperatures");
+  const [temperatures] = getBackendSyncedSignal("temperatures");
   const now = useNowMs(5000);
   const readings = createMemo(() => Object.values(temperatures() ?? {}).sort((a, b) => a.label.localeCompare(b.label)));
   const newestTime = createMemo(() => Math.max(0, ...readings().map(reading => reading.time)));

--- a/frontend/src/components/dashboard/WaterHeaterCard.tsx
+++ b/frontend/src/components/dashboard/WaterHeaterCard.tsx
@@ -12,8 +12,8 @@ import type { ElpatronDisplayState } from "../../../../backend/src/sharedTypes";
  * pushed from the heating pi via the controller so what the card claims is what the element does.
  */
 export function WaterHeaterCard() {
-  const [config, setConfig] = getBackendSyncedSignal<Config>("config");
-  const [elpatronState] = getBackendSyncedSignal<ElpatronDisplayState>("elpatronState", undefined, true, true);
+  const [config, setConfig] = getBackendSyncedSignal("config");
+  const [elpatronState] = getBackendSyncedSignal("elpatronState", undefined, true, true);
   const owner = getOwner()!;
   const now = useNowMs(5000);
   const switching = () => config()?.elpatron_switching;

--- a/frontend/src/components/system/AlertsCard.tsx
+++ b/frontend/src/components/system/AlertsCard.tsx
@@ -12,8 +12,8 @@ import "./AlertsCard.scss";
  * button every family phone gets verified with. Thresholds live in the alerting config section.
  */
 export function AlertsCard() {
-  const [recentAlerts] = getBackendSyncedSignal<AlertRecord[]>("recentAlerts", undefined, true, true);
-  const [config] = getBackendSyncedSignal<Config>("config", undefined, false);
+  const [recentAlerts] = getBackendSyncedSignal("recentAlerts", undefined, true, true);
+  const [config] = getBackendSyncedSignal("config", undefined, false);
   const socket = useWebSocket();
   const owner = getOwner()!;
   const now = useNowMs(5000);

--- a/frontend/src/components/system/DiagnosticsCards.tsx
+++ b/frontend/src/components/system/DiagnosticsCards.tsx
@@ -37,19 +37,19 @@ function DiagRow(props: { label: string; value: string; title?: string }) {
 }
 
 function SocLedgers() {
-  const [socSinceFull] = getBackendSyncedSignal<number>("socSinceFull");
-  const [socSinceEmpty] = getBackendSyncedSignal<number>("socSinceEmpty");
-  const [socAh] = getBackendSyncedSignal<number>("socAh");
-  const [averageSOC] = getBackendSyncedSignal<number>("averageSOC");
-  const [assumedCapacity] = getBackendSyncedSignal<number>("assumedCapacity");
-  const [assumedParasiticConsumption] = getBackendSyncedSignal<number>("assumedParasiticConsumption");
-  const [energyRemovedSinceFull] = getBackendSyncedSignal<number>("energyRemovedSinceFull");
-  const [energyAddedSinceEmpty] = getBackendSyncedSignal<number>("energyAddedSinceEmpty");
-  const [totalLastFull] = getBackendSyncedSignal<string>("totalLastFull");
-  const [totalLastEmpty] = getBackendSyncedSignal<number>("totalLastEmpty");
-  const [isCharging] = getBackendSyncedSignal<number>("isCharging");
-  const [line_power_direction] = getBackendSyncedSignal<MqttValue>("line_power_direction");
-  const [config] = getBackendSyncedSignal<Config>("config", undefined, false);
+  const [socSinceFull] = getBackendSyncedSignal("socSinceFull");
+  const [socSinceEmpty] = getBackendSyncedSignal("socSinceEmpty");
+  const [socAh] = getBackendSyncedSignal("socAh");
+  const [averageSOC] = getBackendSyncedSignal("averageSOC");
+  const [assumedCapacity] = getBackendSyncedSignal("assumedCapacity");
+  const [assumedParasiticConsumption] = getBackendSyncedSignal("assumedParasiticConsumption");
+  const [energyRemovedSinceFull] = getBackendSyncedSignal("energyRemovedSinceFull");
+  const [energyAddedSinceEmpty] = getBackendSyncedSignal("energyAddedSinceEmpty");
+  const [totalLastFull] = getBackendSyncedSignal("totalLastFull");
+  const [totalLastEmpty] = getBackendSyncedSignal("totalLastEmpty");
+  const [isCharging] = getBackendSyncedSignal("isCharging");
+  const [line_power_direction] = getBackendSyncedSignal("line_power_direction");
+  const [config] = getBackendSyncedSignal("config", undefined, false);
   const now = useNowMs(1000);
   const ahLedgerConfig = () => config()?.soc_calculations?.ah_ledger;
 
@@ -99,13 +99,11 @@ function SocLedgers() {
 }
 
 function CurrentSensors() {
-  const [voltageSagMillivoltsRaw] = getBackendSyncedSignal<{ value: number; time: number }>("voltageSagMillivoltsRaw");
-  const [voltageSagMillivoltsAveraged] = getBackendSyncedSignal<number>("voltageSagMillivoltsAveraged");
-  const [voltageSagMillivoltsRaw2] = getBackendSyncedSignal<{ value: number; time: number }>(
-    "voltageSagMillivoltsRaw2"
-  );
-  const [voltageSagMillivoltsAveraged2] = getBackendSyncedSignal<number>("voltageSagMillivoltsAveraged2");
-  const [config] = getBackendSyncedSignal<Config>("config", undefined, false);
+  const [voltageSagMillivoltsRaw] = getBackendSyncedSignal("voltageSagMillivoltsRaw");
+  const [voltageSagMillivoltsAveraged] = getBackendSyncedSignal("voltageSagMillivoltsAveraged");
+  const [voltageSagMillivoltsRaw2] = getBackendSyncedSignal("voltageSagMillivoltsRaw2");
+  const [voltageSagMillivoltsAveraged2] = getBackendSyncedSignal("voltageSagMillivoltsAveraged2");
+  const [config] = getBackendSyncedSignal("config", undefined, false);
 
   const currentFromMv = (
     millivolts: number | undefined,
@@ -163,17 +161,13 @@ function CurrentSensors() {
 }
 
 function NoBuyDebug() {
-  const [solar_input_power_1] = getBackendSyncedSignal<MqttValue>("solar_input_power_1");
-  const [solar_input_power_2] = getBackendSyncedSignal<MqttValue>("solar_input_power_2");
-  const [ac_output_active_power_r] = getBackendSyncedSignal<MqttValue>("ac_output_active_power_r");
-  const [ac_output_active_power_s] = getBackendSyncedSignal<MqttValue>("ac_output_active_power_s");
-  const [ac_output_active_power_t] = getBackendSyncedSignal<MqttValue>("ac_output_active_power_t");
-  const [lastFeedWhenNoSolarReason] = getBackendSyncedSignal<{ what: string; when: number }>(
-    "lastFeedWhenNoSolarReason"
-  );
-  const [lastChangingFeedWhenNoSolarReason] = getBackendSyncedSignal<{ what: string; when: number }>(
-    "lastChangingFeedWhenNoSolarReason"
-  );
+  const [solar_input_power_1] = getBackendSyncedSignal("solar_input_power_1");
+  const [solar_input_power_2] = getBackendSyncedSignal("solar_input_power_2");
+  const [ac_output_active_power_r] = getBackendSyncedSignal("ac_output_active_power_r");
+  const [ac_output_active_power_s] = getBackendSyncedSignal("ac_output_active_power_s");
+  const [ac_output_active_power_t] = getBackendSyncedSignal("ac_output_active_power_t");
+  const [lastFeedWhenNoSolarReason] = getBackendSyncedSignal("lastFeedWhenNoSolarReason");
+  const [lastChangingFeedWhenNoSolarReason] = getBackendSyncedSignal("lastChangingFeedWhenNoSolarReason");
   const now = useNowMs(1000);
 
   const solarPower = createMemo(

--- a/frontend/src/components/system/LiveReadings.tsx
+++ b/frontend/src/components/system/LiveReadings.tsx
@@ -8,26 +8,26 @@ import "./LiveReadings.scss";
 const STALE_AFTER_MS = 60_000;
 
 export function LiveReadings() {
-  const [currentBatteryPower] = getBackendSyncedSignal<CurrentBatteryPowerBroadcast>("currentBatteryPower");
-  const [battery_voltage] = getBackendSyncedSignal<MqttValue>("battery_voltage");
-  const [battery_current] = getBackendSyncedSignal<MqttValue>("battery_current");
-  const [solar_input_power_1] = getBackendSyncedSignal<MqttValue>("solar_input_power_1");
-  const [solar_input_current_1] = getBackendSyncedSignal<MqttValue>("solar_input_current_1");
-  const [solar_input_current_2] = getBackendSyncedSignal<MqttValue>("solar_input_current_2");
-  const [solar_input_voltage_1] = getBackendSyncedSignal<MqttValue>("solar_input_voltage_1");
-  const [solar_input_voltage_2] = getBackendSyncedSignal<MqttValue>("solar_input_voltage_2");
-  const [solar_input_power_2] = getBackendSyncedSignal<MqttValue>("solar_input_power_2");
-  const [ac_output_total_active_power] = getBackendSyncedSignal<MqttValue>("ac_output_total_active_power");
-  const [ac_input_total_active_power] = getBackendSyncedSignal<MqttValue>("ac_input_total_active_power");
-  const [ac_input_active_power_r] = getBackendSyncedSignal<MqttValue>("ac_input_active_power_r");
-  const [ac_input_active_power_s] = getBackendSyncedSignal<MqttValue>("ac_input_active_power_s");
-  const [ac_input_active_power_t] = getBackendSyncedSignal<MqttValue>("ac_input_active_power_t");
-  const [ac_output_active_power_r] = getBackendSyncedSignal<MqttValue>("ac_output_active_power_r");
-  const [ac_output_active_power_s] = getBackendSyncedSignal<MqttValue>("ac_output_active_power_s");
-  const [ac_output_active_power_t] = getBackendSyncedSignal<MqttValue>("ac_output_active_power_t");
-  const [ac_input_voltage_r] = getBackendSyncedSignal<MqttValue>("ac_input_voltage_r");
-  const [ac_input_voltage_s] = getBackendSyncedSignal<MqttValue>("ac_input_voltage_s");
-  const [ac_input_voltage_t] = getBackendSyncedSignal<MqttValue>("ac_input_voltage_t");
+  const [currentBatteryPower] = getBackendSyncedSignal("currentBatteryPower");
+  const [battery_voltage] = getBackendSyncedSignal("battery_voltage");
+  const [battery_current] = getBackendSyncedSignal("battery_current");
+  const [solar_input_power_1] = getBackendSyncedSignal("solar_input_power_1");
+  const [solar_input_current_1] = getBackendSyncedSignal("solar_input_current_1");
+  const [solar_input_current_2] = getBackendSyncedSignal("solar_input_current_2");
+  const [solar_input_voltage_1] = getBackendSyncedSignal("solar_input_voltage_1");
+  const [solar_input_voltage_2] = getBackendSyncedSignal("solar_input_voltage_2");
+  const [solar_input_power_2] = getBackendSyncedSignal("solar_input_power_2");
+  const [ac_output_total_active_power] = getBackendSyncedSignal("ac_output_total_active_power");
+  const [ac_input_total_active_power] = getBackendSyncedSignal("ac_input_total_active_power");
+  const [ac_input_active_power_r] = getBackendSyncedSignal("ac_input_active_power_r");
+  const [ac_input_active_power_s] = getBackendSyncedSignal("ac_input_active_power_s");
+  const [ac_input_active_power_t] = getBackendSyncedSignal("ac_input_active_power_t");
+  const [ac_output_active_power_r] = getBackendSyncedSignal("ac_output_active_power_r");
+  const [ac_output_active_power_s] = getBackendSyncedSignal("ac_output_active_power_s");
+  const [ac_output_active_power_t] = getBackendSyncedSignal("ac_output_active_power_t");
+  const [ac_input_voltage_r] = getBackendSyncedSignal("ac_input_voltage_r");
+  const [ac_input_voltage_s] = getBackendSyncedSignal("ac_input_voltage_s");
+  const [ac_input_voltage_t] = getBackendSyncedSignal("ac_input_voltage_t");
   const now = useNowMs(1000);
 
   const solarInput = createMemo(() => {

--- a/frontend/src/helpers/getBackendSyncedSignal.tsx
+++ b/frontend/src/helpers/getBackendSyncedSignal.tsx
@@ -102,7 +102,8 @@ export function getBackendSyncedSignal<K extends WsSignalKey>(
   const message_handler = ({ data }: MessageEvent) => {
     const decoded = JSON.parse(data);
     if (decoded.type === "change" && decoded.key === key) {
-      set_actual_signal(decoded.value);
+      // functional form like the other setters — a bare value would be *called* if it were a function
+      set_actual_signal(() => decoded.value);
     }
   };
   const requestValueUpdate = async () => {

--- a/frontend/src/helpers/getBackendSyncedSignal.tsx
+++ b/frontend/src/helpers/getBackendSyncedSignal.tsx
@@ -1,14 +1,20 @@
-import { Accessor, createEffect, createSignal, getOwner, onCleanup, Signal } from "solid-js";
+import { type Accessor, createEffect, createSignal, getOwner, onCleanup } from "solid-js";
 import { random_string } from "@depict-ai/utilishared/latest";
 import { useVisibilityState } from "@depict-ai/ui/latest";
 import { showToastWithMessage } from "~/helpers/showToastWithMessage";
 import { useWebSocket } from "~/components/WebSocketProvider";
 import { isServer } from "solid-js/web";
+import type {
+  WsAction,
+  WsExposedSignals,
+  WsSignalKey,
+  WsWritableSignalKey,
+} from "../../../backend/src/wsContract.types";
 
 /** Fire a backend action (command: "action") and return its result string, or undefined on failure. */
 export async function sendBackendAction(
   socket: ReturnType<typeof useWebSocket>,
-  action: string
+  action: WsAction
 ): Promise<string | undefined> {
   const [response] = (await socket?.ensure_sent({
     id: random_string(),
@@ -20,22 +26,78 @@ export async function sendBackendAction(
   throw new Error(response.message || "Action failed");
 }
 
-export function getBackendSyncedSignal<T, default_value_was_provided extends boolean = false>(
-  key: string,
-  default_value?: T,
+/** Only `config` is writable server-side; for every other key the setter type is `never`. */
+type BackendSetter<K extends WsSignalKey> = K extends WsWritableSignalKey
+  ? (new_value: WsExposedSignals[K]) => Promise<boolean | undefined>
+  : never;
+
+/**
+ * A signal mirroring one backend-exposed value, typed by the ws contract (wsContract.types.ts):
+ * the key must exist there and the value type is inferred from it — a typo'd key or a wrongly
+ * assumed shape fails to compile instead of failing at runtime.
+ */
+// With a default value the accessor never yields undefined
+export function getBackendSyncedSignal<K extends WsSignalKey>(
+  key: K,
+  default_value: WsExposedSignals[K],
+  refetchOnVisibilityChange?: boolean,
+  silentReadErrors?: boolean
+): readonly [Accessor<WsExposedSignals[K]>, BackendSetter<K>];
+// Without one, undefined means "hasn't arrived yet"
+export function getBackendSyncedSignal<K extends WsSignalKey>(
+  key: K,
+  default_value?: undefined,
+  refetchOnVisibilityChange?: boolean,
+  silentReadErrors?: boolean
+): readonly [Accessor<WsExposedSignals[K] | undefined>, BackendSetter<K>];
+export function getBackendSyncedSignal<K extends WsSignalKey>(
+  key: K,
+  default_value?: WsExposedSignals[K],
   refetchOnVisibilityChange = true,
   /** Log read failures to the console instead of toasting — for keys an older backend may not expose yet. */
   silentReadErrors = false
 ) {
+  type Value = WsExposedSignals[K] | undefined;
   const socket = useWebSocket();
-  const signal = createSignal<T>(default_value!);
+  const owner = getOwner();
+  const [get_value, set_actual_signal] = createSignal<Value>(default_value);
+
+  const write = async (new_value: WsExposedSignals[K]) => {
+    set_actual_signal(() => new_value); // set the signal immediately, since that's what's expected of a signal and we kind of want to emulate that
+    try {
+      const [response] = (await socket?.ensure_sent({
+        id: random_string(),
+        command: "write",
+        key,
+        value: new_value,
+      })) as [
+        {
+          id: string;
+          status: "ok" | "not-ok";
+          value: unknown;
+          message?: string;
+        },
+        string,
+      ];
+      if (response.status === "ok") {
+        return true;
+      }
+      console.error(response);
+      throw response.message;
+    } catch (e) {
+      console.error(e);
+      if (owner) await showToastWithMessage(owner, () => `Error writing ${key}: ${e}`);
+    }
+    return false;
+  };
+  // The runtime write function exists for every key (the backend rejects non-writable ones);
+  // the conditional type narrows it away at compile time for read-only keys.
+  const result = [get_value, write] as unknown as readonly [Accessor<Value>, BackendSetter<K>];
 
   if (isServer) {
-    return signal as default_value_was_provided extends true ? Signal<T> : Signal<T | undefined>;
+    return result;
   }
 
-  const [get_value, set_actual_signal] = signal;
-  const owner = getOwner()!;
   const pageIsVisible = useVisibilityState();
   const message_handler = ({ data }: MessageEvent) => {
     const decoded = JSON.parse(data);
@@ -52,21 +114,21 @@ export function getBackendSyncedSignal<T, default_value_was_provided extends boo
       {
         id: string;
         status: "ok" | "not-ok";
-        value: any;
+        value: Value;
       },
       string,
     ];
     if (response.status === "ok") {
-      set_actual_signal(response.value);
+      set_actual_signal(() => response.value);
     } else if (silentReadErrors) {
       console.warn(`Backend can't provide ${key} (yet?):`, response_json);
     } else {
       console.error(response);
-      await showToastWithMessage(owner, () => `Error reading ${key}: ${response_json}`);
+      if (owner) await showToastWithMessage(owner, () => `Error reading ${key}: ${response_json}`);
     }
   };
-  socket?.addEventListener("message", message_handler as any);
-  onCleanup(() => socket?.removeEventListener("message", message_handler as any));
+  socket?.addEventListener("message", message_handler as EventListener);
+  onCleanup(() => socket?.removeEventListener("message", message_handler as EventListener));
 
   // Initially, and when leaving the tab and coming back, poll for current values
   // Otherwise when opening a tab that has been suspended for a while, we will show ancient values until a new broadcast comes in for that value
@@ -76,35 +138,5 @@ export function getBackendSyncedSignal<T, default_value_was_provided extends boo
     requestValueUpdate();
   }
 
-  return [
-    get_value as default_value_was_provided extends true ? Accessor<T> : Accessor<T | undefined>,
-    async (new_value: T) => {
-      set_actual_signal(() => new_value); // set the signal immediately, since that's what's expected of a signal and we kind of want to emulate that
-      try {
-        const [response] = (await socket?.ensure_sent({
-          id: random_string(),
-          command: "write",
-          key,
-          value: new_value,
-        })) as [
-          {
-            id: string;
-            status: "ok" | "not-ok";
-            value: any;
-            message?: string;
-          },
-          string,
-        ];
-        if (response.status === "ok") {
-          return true;
-        }
-        console.error(response);
-        throw response.message;
-      } catch (e) {
-        console.error(e);
-        await showToastWithMessage(owner, () => `Error writing ${key}: ${e}`);
-      }
-      return false;
-    },
-  ] as const;
+  return result;
 }

--- a/frontend/src/routes/temperatures.tsx
+++ b/frontend/src/routes/temperatures.tsx
@@ -7,7 +7,7 @@ import type { TemperatureReadingBroadcast } from "../../../backend/src/sharedTyp
 import "./temperatures.scss";
 
 export default function Temperatures() {
-  const [get_temperatures] = getBackendSyncedSignal<Record<string, TemperatureReadingBroadcast>, true>("temperatures", {
+  const [get_temperatures] = getBackendSyncedSignal("temperatures", {
     loading: {
       value: 0,
       time: 0,


### PR DESCRIPTION
Stacked on #38.

One pure file — `backend/src/wsContract.types.ts` — now maps every ws-exposed key to its wire type, and both sides are compiler-bound to it:

- **Backend**: `wsMessaging`'s `exposedAccessors`/`actions` parameters are typed by the contract. Exposing a key with the wrong shape, or forgetting one, no longer compiles.
- **Frontend**: `getBackendSyncedSignal(key)` takes `keyof` the contract and infers the value type — the caller-asserted `<T>` is gone from all call sites. Overloads express "default value ⇒ accessor never undefined", the setter is `never` for everything except `config`, and `sendBackendAction` takes a `WsAction` union.

The migration caught three standing lies, which is the argument for the whole thing:
- `isCharging` was consumed as `number`; it's a boolean chain.
- `totalLastFull`'s `&& toISOString()` could leak a raw `0` onto the wire.
- The temperatures record could hold `undefined` entries in memory that `JSON.stringify` silently dropped — now filtered server-side and typed honestly.

Verified with a negative test (not committed): a typo'd key, a wrongly assumed shape, a write to a read-only key and an unknown action are all compile errors. Runtime smoke-tested against the live pi. Types only on the wire — no deploy needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAZ1X2Zdh7MXiQc7m6VXiu