### PR TITLE
Elpatron model: stove-gated history subtraction, day-capped manual arming

### DIFF
--- a/backend/src/autoTrading/autoTrader.ts
+++ b/backend/src/autoTrading/autoTrader.ts
@@ -348,10 +348,15 @@ async function buildPlannerInput(
     solarWattsAt: solar.wattsAt,
     nowMs,
   });
+  // Strip the element's share out of the learned history whenever the stove is off — element
+  // days linger in the 14-day median after disarming, so gating on "armed now" re-inflated the
+  // baseline the moment guests left. Unknown stove state (pi unreachable) falls back to the
+  // armed gate, which is safe in both seasons.
+  const subtractElpatronHistory = elpatron.stoveOn === false || (elpatron.stoveOn === undefined && elpatron.armed);
   const consumption = await fetchConsumptionForecast(
     ctx.influxClient(),
     tradingConfig.fallback_house_load_watts,
-    elpatron.armed ? cfg.elpatron_switching : undefined
+    subtractElpatronHistory ? cfg.elpatron_switching : undefined
   );
   const { sells, buys } = userWindows(ctx, cfg);
   return {

--- a/backend/src/autoTrading/consumptionForecast.ts
+++ b/backend/src/autoTrading/consumptionForecast.ts
@@ -14,6 +14,7 @@ export type ElpatronHistoryKnobs = {
   element_watts: number;
   tank_wh_per_degree: number;
   tank_cooling_degrees_per_hour: number;
+  tank_max_temperature: number;
 };
 
 let cache: (ConsumptionForecast & { elpatronKey: string }) | undefined;
@@ -30,11 +31,13 @@ function localHour(ms: number): number {
  * Median over days is used so that rare heavy loads (EV charging sessions) don't inflate the baseline —
  * those are exactly what the user handles manually via the extra-reserve knob.
  *
- * When `subtractElpatron` is set (the water heater element is currently armed — see
- * elpatronForecast.ts), the element's share is stripped from each historical hour first, using the
- * tank sensor: energy into the tank ≈ heat capacity × (ΔT + standing loss). The planner adds the
- * element back as a modeled forward load, so leaving it in the baseline would double-count it.
- * Not applied in stove season (element unarmed), where tank warming is the pellet stove's doing.
+ * When `subtractElpatron` is set (the pellet stove is off, so the element is the tank's only heat
+ * source — the caller gates on live stove state, see buildPlannerInput), the element's share is
+ * stripped from each historical hour, using the tank sensor: energy into the tank ≈ heat capacity
+ * × (ΔT + standing loss). The forward model adds the element back whenever it's armed, so leaving
+ * it in the baseline would double-count it — and element days linger in this 14-day window after
+ * disarming, which is why the gate is the stove, not the element's current armed state.
+ * Not applied in stove season, where tank warming is the boiler's doing.
  */
 export async function fetchConsumptionForecast(
   influxClient: Influx.InfluxDB | undefined,
@@ -151,7 +154,15 @@ async function estimateElpatronHistory(
     const nextTank = tankByMs.get(ms + hourMs);
     if (nextTank === undefined) continue;
     const deltaDegrees = nextTank - tank;
-    const estimatedW = knobs.tank_wh_per_degree * (deltaDegrees + knobs.tank_cooling_degrees_per_hour);
+    // The standing-loss term only belongs to hours the element could have been compensating it:
+    // a rising tank, or a flat one held near the thermostat band. A tank coasting well below the
+    // band cools slower than the (hot-tank-calibrated) constant, and crediting the difference to
+    // the element invented a few hundred phantom watts on quiet nights — enough to out-dominate
+    // a small house load and get real samples dropped.
+    const elementCouldBeActive = deltaDegrees > 0 || tank >= knobs.tank_max_temperature - 5;
+    const estimatedW = elementCouldBeActive
+      ? knobs.tank_wh_per_degree * (deltaDegrees + knobs.tank_cooling_degrees_per_hour)
+      : 0;
     elpatronWByMs.set(ms, Math.min(knobs.element_watts, Math.max(0, estimatedW)));
   }
   return elpatronWByMs;

--- a/backend/src/autoTrading/elpatronForecast.ts
+++ b/backend/src/autoTrading/elpatronForecast.ts
@@ -13,7 +13,7 @@
 
 import Influx from "influx";
 import { warnLog } from "../utilities/logging.ts";
-import { readElpatronGpioIsOn } from "../utilities/heatingPi.ts";
+import { readHeatingGpio } from "../utilities/heatingPi.ts";
 import { resolveElpatronMode } from "../sharedTypes.ts";
 import type { Config } from "../config/config.types.ts";
 
@@ -22,9 +22,21 @@ export type ElpatronForecast = {
   wattsAt: (ms: number) => number;
   armed: boolean;
   tankTempC: number | undefined;
+  /**
+   * Whether the pellet stove output is on (undefined = heating pi unreachable). While the stove
+   * is definitely off, the element is the tank's only heat source — which is what licenses the
+   * consumption history subtraction regardless of the element's current armed state.
+   */
+  stoveOn: boolean | undefined;
 };
 
-const UNARMED: Omit<ElpatronForecast, "armed"> = { wattsAt: () => 0, tankTempC: undefined };
+/**
+ * A manually-switched-on element (mode off, GPIO on by hand) is a point-in-time observation, not
+ * a policy: extrapolating it as permanent projected ~11 kWh/day of phantom thermostat top-ups for
+ * the whole horizon (the 2026-07-16/17 over-forecast + guard churn). Model it for one day ahead —
+ * the 15-min guard re-plans keep rolling that window forward for as long as it actually stays on.
+ */
+const MANUAL_ON_MODEL_HORIZON_MS = 24 * 3600 * 1000;
 
 export async function fetchElpatronForecast({
   elpatronConfig,
@@ -37,30 +49,33 @@ export async function fetchElpatronForecast({
   solarWattsAt: (ms: number) => number;
   nowMs: number;
 }): Promise<ElpatronForecast> {
-  // Armed = we actively switch it (solar or always-on mode), or someone left the element GPIO on
-  // manually. The gpio read is skipped when a mode is active — armed either way.
+  // Always read the gpio: even with a switching mode active (armed either way), the stove state
+  // decides whether the history subtraction may run
+  const gpio = await readHeatingGpio(elpatronConfig.heating_pi_ip);
   const elpatronMode = resolveElpatronMode(elpatronConfig);
-  let armed = elpatronMode !== "off";
-  if (!armed) {
-    armed = (await readElpatronGpioIsOn(elpatronConfig.heating_pi_ip)) === true;
-  }
-  if (!armed) return { ...UNARMED, armed: false };
+  const armed = elpatronMode !== "off" || gpio?.elementOn === true;
+  if (!armed) return { wattsAt: () => 0, armed: false, tankTempC: undefined, stoveOn: gpio?.stoveOn };
 
   const tankTempC = await fetchTankTemperature(influxClient);
   // Without a tank reading, assume mid-band: still predicts a plausible dawn burn + top-ups
   const startTempC = tankTempC ?? elpatronConfig.tank_max_temperature - 5;
+  const heatingAllowedAt =
+    elpatronMode === "solar"
+      ? (ms: number) => solarWattsAt(ms) > elpatronConfig.min_solar_input
+      : elpatronMode === "always_on"
+        ? () => true
+        : // Armed only via the hand-switched GPIO — see MANUAL_ON_MODEL_HORIZON_MS
+          (ms: number) => ms - nowMs < MANUAL_ON_MODEL_HORIZON_MS;
   const wattsAt = buildElpatronLoadModel({
     nowMs,
     startTempC,
-    // In always-on mode — or off mode with the GPIO left on by hand — only the tank thermostat
-    // limits the element
-    heatingAllowedAt: elpatronMode === "solar" ? ms => solarWattsAt(ms) > elpatronConfig.min_solar_input : () => true,
+    heatingAllowedAt,
     element_watts: elpatronConfig.element_watts,
     tank_wh_per_degree: elpatronConfig.tank_wh_per_degree,
     tank_cooling_degrees_per_hour: elpatronConfig.tank_cooling_degrees_per_hour,
     tank_max_temperature: elpatronConfig.tank_max_temperature,
   });
-  return { wattsAt, armed: true, tankTempC };
+  return { wattsAt, armed: true, tankTempC, stoveOn: gpio?.stoveOn };
 }
 
 /**

--- a/backend/src/autoTrading/planPreview.ts
+++ b/backend/src/autoTrading/planPreview.ts
@@ -60,12 +60,14 @@ const elpatron = await fetchElpatronForecast({
   nowMs: Date.now(),
 });
 console.log(
-  `Elpatron: ${elpatron.armed ? `armed, tank ${elpatron.tankTempC ?? "?"}°C — modeled as known load` : "not armed"}\n`
+  `Elpatron: ${elpatron.armed ? `armed, tank ${elpatron.tankTempC ?? "?"}°C — modeled as known load` : "not armed"}, stove on: ${elpatron.stoveOn ?? "unknown"}\n`
 );
+// Same gate as buildPlannerInput: stove off ⇒ history subtraction runs regardless of armed state
+const subtractElpatronHistory = elpatron.stoveOn === false || (elpatron.stoveOn === undefined && elpatron.armed);
 const consumption = await fetchConsumptionForecast(
   influxClient,
   at.fallback_house_load_watts,
-  elpatron.armed ? elpatronConfig : undefined
+  subtractElpatronHistory ? elpatronConfig : undefined
 );
 
 const fixedSells = Object.entries(config.scheduled_power_selling.schedule)

--- a/backend/src/autoTrading/planner.selftest.ts
+++ b/backend/src/autoTrading/planner.selftest.ts
@@ -595,14 +595,25 @@ function check(name: string, cond: boolean, detail = "") {
     dayKwh > 8 && dayKwh < 16,
     `(${dayKwh.toFixed(1)} kWh)`
   );
-  // GPIO on without solar switching: only the thermostat limits it — top-ups continue at night
+  // always_on mode: only the thermostat limits it — top-ups continue at night
   const ungated = buildElpatronLoadModel({
     nowMs: t0,
     startTempC: 50,
     heatingAllowedAt: () => true,
     ...elpatronKnobs,
   });
-  check("elpatron: manual-on holds the band around the clock", ungated(t0 + 20 * H) === 480);
+  check("elpatron: always-on mode holds the band around the clock", ungated(t0 + 20 * H) === 480);
+  // A hand-switched GPIO is a point-in-time observation: modeled for one day, not extrapolated
+  // forever (the 2026-07-16/17 over-forecast). Rolling re-plans re-extend while it stays on.
+  const manualOnHorizonMs = 24 * H;
+  const manual = buildElpatronLoadModel({
+    nowMs: t0,
+    startTempC: 50,
+    heatingAllowedAt: ms => ms - t0 < manualOnHorizonMs,
+    ...elpatronKnobs,
+  });
+  check("elpatron: manual-on modeled within the first day", manual(t0 + 20 * H) === 480);
+  check("elpatron: manual-on not extrapolated past a day", manual(t0 + 30 * H) === 0, `(${manual(t0 + 30 * H)} W)`);
 }
 
 console.log(fails.length ? `\n${fails.length} FAILURES: ${fails.join(", ")}` : "\nAll scenarios passed");

--- a/backend/src/utilities/heatingPi.ts
+++ b/backend/src/utilities/heatingPi.ts
@@ -23,30 +23,46 @@ export function getHeatingPiSocket(heatingPiIp: string): DepictAPIWS {
   return socket;
 }
 
-let gpioReadCache: { heatingPiIp: string; atMs: number; value: boolean | undefined } | undefined;
+/** Both pins are active-low (raw 0 = powered); undefined = the output was missing in the reply */
+export type HeatingGpioSnapshot = { elementOn: boolean | undefined; stoveOn: boolean | undefined };
+
+let gpioReadCache: { heatingPiIp: string; atMs: number; value: HeatingGpioSnapshot | undefined } | undefined;
 
 /**
- * Whether the element GPIO is currently on (the pin is active-low: raw 0 = element powered).
- * Returns undefined when the heating pi doesn't answer in time — ensure_sent retries forever, and
- * a plan run must not hang on an unreachable pi in another building. Results (including failures)
- * are cached (default 10 minutes) so the guard's 15-min ticks don't hammer or stall on the pi;
- * the frontend's live state poll passes a shorter maxAge.
+ * Current heating-pi output states: the water heater element and the pellet stove (the latter
+ * tells the consumption model whether the element can be assumed to be the tank's only heat
+ * source). Returns undefined when the heating pi doesn't answer in time — ensure_sent retries
+ * forever, and a plan run must not hang on an unreachable pi in another building. Results
+ * (including failures) are cached (default 10 minutes) so the guard's 15-min ticks don't hammer
+ * or stall on the pi; the frontend's live state poll passes a shorter maxAge.
  */
-export async function readElpatronGpioIsOn(heatingPiIp: string, maxAgeMs = 10 * 60_000): Promise<boolean | undefined> {
+export async function readHeatingGpio(
+  heatingPiIp: string,
+  maxAgeMs = 10 * 60_000
+): Promise<HeatingGpioSnapshot | undefined> {
   if (gpioReadCache && gpioReadCache.heatingPiIp === heatingPiIp && Date.now() - gpioReadCache.atMs < maxAgeMs) {
     return gpioReadCache.value;
   }
-  const value = await readElpatronGpioUncached(heatingPiIp);
+  const value = await readHeatingGpioUncached(heatingPiIp);
   gpioReadCache = { heatingPiIp, atMs: Date.now(), value };
   return value;
 }
 
-/** After we wrote the GPIO ourselves the state is known — spare the next reader a roundtrip. */
-export function primeElpatronGpioCache(heatingPiIp: string, isOn: boolean) {
-  gpioReadCache = { heatingPiIp, atMs: Date.now(), value: isOn };
+/** Whether the element GPIO is currently on. See readHeatingGpio for semantics and caching. */
+export async function readElpatronGpioIsOn(heatingPiIp: string, maxAgeMs = 10 * 60_000): Promise<boolean | undefined> {
+  return (await readHeatingGpio(heatingPiIp, maxAgeMs))?.elementOn;
 }
 
-async function readElpatronGpioUncached(heatingPiIp: string): Promise<boolean | undefined> {
+/**
+ * After we wrote the element GPIO ourselves the state is known — spare the next reader a
+ * roundtrip. Keeps the previously-read stove state; a write only changes the element.
+ */
+export function primeElpatronGpioCache(heatingPiIp: string, isOn: boolean) {
+  const previousStoveOn = gpioReadCache?.heatingPiIp === heatingPiIp ? gpioReadCache.value?.stoveOn : undefined;
+  gpioReadCache = { heatingPiIp, atMs: Date.now(), value: { elementOn: isOn, stoveOn: previousStoveOn } };
+}
+
+async function readHeatingGpioUncached(heatingPiIp: string): Promise<HeatingGpioSnapshot | undefined> {
   const socket = getHeatingPiSocket(heatingPiIp);
   const request = socket.ensure_sent({ id: random_string(), command: "read", key: "gpio" }) as Promise<
     [{ status: string; value?: { outputs?: Record<string, number> } }, unknown]
@@ -57,10 +73,13 @@ async function readElpatronGpioUncached(heatingPiIp: string): Promise<boolean | 
     warnLog("Heating pi: gpio read failed or timed out", heatingPiIp, result);
     return undefined;
   }
-  const rawState = result.value?.outputs?.electric_heating_element;
-  if (rawState === undefined) {
+  const outputs = result.value?.outputs;
+  if (outputs?.electric_heating_element === undefined) {
     warnLog("Heating pi: gpio response has no electric_heating_element output", result.value);
     return undefined;
   }
-  return rawState === 0;
+  return {
+    elementOn: outputs.electric_heating_element === 0,
+    stoveOn: outputs.stove === undefined ? undefined : outputs.stove === 0,
+  };
 }


### PR DESCRIPTION
Two behavioral gaps from week one of the elpatron-as-known-load model, plus an estimator artifact found while validating:

## 1. History subtraction gated on the stove, not on "armed now"

When the guests left and the element went off, the subtraction stopped — but element days linger in the 14-day median, so the baseline re-absorbed them (predicted house 33–38 kWh vs 17–26 actual on Jul 16–17, decaying only as days age out). The license for subtracting is "the element is the tank's only heat source", i.e. **the pellet stove is off** — now read from the stove GPIO in the same (cached, timeout-guarded) heating-pi read that already fetches the element state. Fallbacks: unknown stove state (pi unreachable) → old armed-gated behavior, safe in both seasons; stove on → never subtract, so boiler heat is never misattributed.

## 2. Manual GPIO arming capped at one day

A hand-switched-on element is a point-in-time observation, not a policy. Extrapolating it as permanent projected ~11 kWh/day of phantom top-ups over the whole horizon → chronically "breached" baseline → guard churn spiked to 15–21 breach-replans/day on Jul 16–17. Manual-on is now modeled 24 h ahead; the 15-min guard re-plans keep rolling that window forward for as long as the GPIO actually stays on, so a genuinely persistent manual-on loses at most the far tail. Config-declared `always_on`/`solar` modes are unchanged (explicit intent, uncapped).

## 3. Standing-loss credit only near the thermostat band

The stove-off gate made the subtraction run on quiet nights, exposing this: the 1 °C/h standing-loss constant is calibrated on a hot tank, but a cold coasting tank loses only ~0.4 °C/h — the difference became a few hundred phantom watts credited to the element, which out-dominated small night loads (est > 90 % of house) and got legitimate samples dropped, biasing night/dawn medians high. Standing loss is now credited only when the tank rose or sits within 5 °C of the thermostat cutoff.

**Live validation** (planPreview against the pi's config just now): armed correctly detected via GPIO (element is on — tank rose 33.75 → 34.4 °C during validation), `stove on: false`, and the re-learned residual profile is plausible in every hour — night 190–260 W, hour-05 median down from **2459 W → 466 W**, evening peak intact. Typecheck + all selftest scenarios green (two new checks: manual-on modeled within the first day, not extrapolated past it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gnx4sUB71SzTnG5iP5dcZN