### PR TITLE
Elpatron review follow-ups: fresh stove state, shared gate, tested horizon

### DIFF
--- a/backend/src/autoTrading/autoTrader.ts
+++ b/backend/src/autoTrading/autoTrader.ts
@@ -10,7 +10,7 @@ import { inverterIdleWatts, packCapacityWh } from "../battery/ahLedgerDerivedVal
 import { fetchPrices, type FetchedPrices, getCachedPrices } from "./priceService.ts";
 import { fetchSolarForecast } from "./solarForecast.ts";
 import { fetchConsumptionForecast } from "./consumptionForecast.ts";
-import { fetchElpatronForecast } from "./elpatronForecast.ts";
+import { fetchElpatronForecast, shouldSubtractElpatronHistory } from "./elpatronForecast.ts";
 import {
   type AutoTraderState,
   type AutoTraderStatus,
@@ -348,15 +348,10 @@ async function buildPlannerInput(
     solarWattsAt: solar.wattsAt,
     nowMs,
   });
-  // Strip the element's share out of the learned history whenever the stove is off — element
-  // days linger in the 14-day median after disarming, so gating on "armed now" re-inflated the
-  // baseline the moment guests left. Unknown stove state (pi unreachable) falls back to the
-  // armed gate, which is safe in both seasons.
-  const subtractElpatronHistory = elpatron.stoveOn === false || (elpatron.stoveOn === undefined && elpatron.armed);
   const consumption = await fetchConsumptionForecast(
     ctx.influxClient(),
     tradingConfig.fallback_house_load_watts,
-    subtractElpatronHistory ? cfg.elpatron_switching : undefined
+    shouldSubtractElpatronHistory(elpatron) ? cfg.elpatron_switching : undefined
   );
   const { sells, buys } = userWindows(ctx, cfg);
   return {

--- a/backend/src/autoTrading/consumptionForecast.ts
+++ b/backend/src/autoTrading/consumptionForecast.ts
@@ -128,10 +128,9 @@ export async function fetchConsumptionForecast(
  * steep temperature DROP and clamp to 0; hours holding the thermostat band land near the standing
  * loss — both are what actually happened electrically, to within the calibration.
  *
- * Assumes the element is the ONLY thing heating the tank, which holds when this runs (armed ⇒
- * summer, pellet stove cold). Turning the element GPIO on manually DURING stove season would
- * misattribute stove heat to the element here and under-provision the baseline — if that ever
- * becomes a real combination, gate this on the stove being off (readable from the heating pi).
+ * Assumes the element is the ONLY thing heating the tank. The caller guarantees that by gating
+ * on the stove GPIO being off (shouldSubtractElpatronHistory); only the unknown-stove-state
+ * fallback (heating pi unreachable ⇒ gate on armed) still leans on armed-implies-stove-cold.
  */
 async function estimateElpatronHistory(
   influxClient: Influx.InfluxDB,

--- a/backend/src/autoTrading/elpatronForecast.ts
+++ b/backend/src/autoTrading/elpatronForecast.ts
@@ -35,8 +35,20 @@ export type ElpatronForecast = {
  * a policy: extrapolating it as permanent projected ~11 kWh/day of phantom thermostat top-ups for
  * the whole horizon (the 2026-07-16/17 over-forecast + guard churn). Model it for one day ahead —
  * the 15-min guard re-plans keep rolling that window forward for as long as it actually stays on.
+ * Exported for the selftest so a changed horizon is tested, not a stale copy.
  */
-const MANUAL_ON_MODEL_HORIZON_MS = 24 * 3600 * 1000;
+export const MANUAL_ON_MODEL_HORIZON_MS = 24 * 3600 * 1000;
+
+/**
+ * Whether the learned-baseline subtraction may run (see consumptionForecast.ts): while the pellet
+ * stove is definitely off, the element is the tank's only heat source, so its historical share is
+ * strippable regardless of the element's CURRENT armed state — element days linger in the 14-day
+ * median after disarming. Unknown stove state (heating pi unreachable) falls back to the armed
+ * gate, which is safe in both seasons. One helper so the planner and planPreview cannot drift.
+ */
+export function shouldSubtractElpatronHistory(elpatron: Pick<ElpatronForecast, "armed" | "stoveOn">): boolean {
+  return elpatron.stoveOn === false || (elpatron.stoveOn === undefined && elpatron.armed);
+}
 
 export async function fetchElpatronForecast({
   elpatronConfig,

--- a/backend/src/autoTrading/planPreview.ts
+++ b/backend/src/autoTrading/planPreview.ts
@@ -16,7 +16,7 @@ import { inverterIdleWatts, packCapacityWh } from "../battery/ahLedgerDerivedVal
 import { fetchPrices } from "./priceService.ts";
 import { fetchSolarForecast } from "./solarForecast.ts";
 import { fetchConsumptionForecast } from "./consumptionForecast.ts";
-import { fetchElpatronForecast } from "./elpatronForecast.ts";
+import { fetchElpatronForecast, shouldSubtractElpatronHistory } from "./elpatronForecast.ts";
 import { generatePlan } from "./planner.ts";
 import type { PlannerInput } from "./planner.types.ts";
 
@@ -62,12 +62,10 @@ const elpatron = await fetchElpatronForecast({
 console.log(
   `Elpatron: ${elpatron.armed ? `armed, tank ${elpatron.tankTempC ?? "?"}°C — modeled as known load` : "not armed"}, stove on: ${elpatron.stoveOn ?? "unknown"}\n`
 );
-// Same gate as buildPlannerInput: stove off ⇒ history subtraction runs regardless of armed state
-const subtractElpatronHistory = elpatron.stoveOn === false || (elpatron.stoveOn === undefined && elpatron.armed);
 const consumption = await fetchConsumptionForecast(
   influxClient,
   at.fallback_house_load_watts,
-  subtractElpatronHistory ? elpatronConfig : undefined
+  shouldSubtractElpatronHistory(elpatron) ? elpatronConfig : undefined
 );
 
 const fixedSells = Object.entries(config.scheduled_power_selling.schedule)

--- a/backend/src/autoTrading/planner.selftest.ts
+++ b/backend/src/autoTrading/planner.selftest.ts
@@ -5,7 +5,7 @@
 import { generatePlan, projectWithFixedWindows, SLOT_MS } from "./planner.ts";
 import { fitSolarModel, fitIsPlausibleVsCurrent } from "./solarCalibration.ts";
 import { computeRealizedRevenue } from "./tradingPerformance.ts";
-import { buildElpatronLoadModel } from "./elpatronForecast.ts";
+import { buildElpatronLoadModel, MANUAL_ON_MODEL_HORIZON_MS } from "./elpatronForecast.ts";
 import type { PlannerInput } from "./planner.types.ts";
 
 const H = 3600_000;
@@ -605,11 +605,10 @@ function check(name: string, cond: boolean, detail = "") {
   check("elpatron: always-on mode holds the band around the clock", ungated(t0 + 20 * H) === 480);
   // A hand-switched GPIO is a point-in-time observation: modeled for one day, not extrapolated
   // forever (the 2026-07-16/17 over-forecast). Rolling re-plans re-extend while it stays on.
-  const manualOnHorizonMs = 24 * H;
   const manual = buildElpatronLoadModel({
     nowMs: t0,
     startTempC: 50,
-    heatingAllowedAt: ms => ms - t0 < manualOnHorizonMs,
+    heatingAllowedAt: ms => ms - t0 < MANUAL_ON_MODEL_HORIZON_MS,
     ...elpatronKnobs,
   });
   check("elpatron: manual-on modeled within the first day", manual(t0 + 20 * H) === 480);

--- a/backend/src/elpatronSwitching.ts
+++ b/backend/src/elpatronSwitching.ts
@@ -3,7 +3,12 @@ import { random_string, wait } from "./vendor/depictUtilishared.ts";
 import { useTotalSolarPower } from "./utilities/useTotalSolarPower.ts";
 import { useFromMqttProvider } from "./mqttValues/MQTTValuesProvider.ts";
 import { reactiveBatteryVoltage } from "./mqttValues/mqttHelpers.ts";
-import { getHeatingPiSocket, primeElpatronGpioCache, readElpatronGpioIsOn } from "./utilities/heatingPi.ts";
+import {
+  getHeatingPiSocket,
+  primeElpatronGpioCache,
+  primeHeatingGpioFromBroadcast,
+  readElpatronGpioIsOn,
+} from "./utilities/heatingPi.ts";
 import { logLog, warnLog } from "./utilities/logging.ts";
 import { type ElpatronDisplayState, type ElpatronMode, resolveElpatronMode } from "./sharedTypes.ts";
 import type { DepictAPIWS } from "./vendor/depictUtilishared.ts";
@@ -75,8 +80,9 @@ export function elpatronSwitching(config: Accessor<Config>) {
     const ip = heatingPiIp();
     if (!ip) return;
     const socket = getHeatingPiSocket(ip);
+    // No cache prime here: the readNow path just did a real (cache-refreshing) read, and the
+    // broadcast path primes the full outputs snapshot itself in onMessage
     const applyState = (elementIsOn: boolean | undefined) => {
-      if (elementIsOn !== undefined) primeElpatronGpioCache(ip, elementIsOn);
       setElpatronHeating(elementIsOn);
       if (elementIsOn !== undefined) enforceAlwaysOnAfterExternalOff(elementIsOn);
     };
@@ -88,9 +94,12 @@ export function elpatronSwitching(config: Accessor<Config>) {
       try {
         const decoded = JSON.parse(String((event as MessageEvent).data));
         if (decoded?.type !== "change" || decoded.key !== "gpio") return;
-        const rawState = decoded.value?.outputs?.electric_heating_element;
-        if (rawState === undefined) return;
-        applyState(rawState === 0); // active-low
+        const outputs = decoded.value?.outputs;
+        if (outputs?.electric_heating_element === undefined) return;
+        // The broadcast carries every output's fresh state — including the stove, which the
+        // consumption model's subtraction gate reads
+        primeHeatingGpioFromBroadcast(ip, outputs);
+        applyState(outputs.electric_heating_element === 0); // active-low
       } catch (e) {
         warnLog("Elpatron: couldn't parse heating pi broadcast", e);
       }

--- a/backend/src/utilities/heatingPi.ts
+++ b/backend/src/utilities/heatingPi.ts
@@ -54,12 +54,34 @@ export async function readElpatronGpioIsOn(heatingPiIp: string, maxAgeMs = 10 * 
 }
 
 /**
- * After we wrote the element GPIO ourselves the state is known — spare the next reader a
- * roundtrip. Keeps the previously-read stove state; a write only changes the element.
+ * After we wrote the element GPIO ourselves the element state is known — spare the next reader a
+ * roundtrip. Only updates the element within the cache's existing freshness window: the carried
+ * stove state was NOT just observed, so a write must not extend the snapshot's age (else frequent
+ * element flips could postpone a real stove read indefinitely).
  */
 export function primeElpatronGpioCache(heatingPiIp: string, isOn: boolean) {
-  const previousStoveOn = gpioReadCache?.heatingPiIp === heatingPiIp ? gpioReadCache.value?.stoveOn : undefined;
-  gpioReadCache = { heatingPiIp, atMs: Date.now(), value: { elementOn: isOn, stoveOn: previousStoveOn } };
+  const previous = gpioReadCache?.heatingPiIp === heatingPiIp ? gpioReadCache : undefined;
+  gpioReadCache = {
+    heatingPiIp,
+    atMs: previous?.atMs ?? 0,
+    value: { elementOn: isOn, stoveOn: previous?.value?.stoveOn },
+  };
+}
+
+/**
+ * A {type:"change", key:"gpio"} broadcast from the heating pi carries the fresh state of ALL
+ * outputs — cache the full snapshot as just-observed.
+ */
+export function primeHeatingGpioFromBroadcast(heatingPiIp: string, outputs: Record<string, number>) {
+  if (outputs.electric_heating_element === undefined) return;
+  gpioReadCache = {
+    heatingPiIp,
+    atMs: Date.now(),
+    value: {
+      elementOn: outputs.electric_heating_element === 0,
+      stoveOn: outputs.stove === undefined ? undefined : outputs.stove === 0,
+    },
+  };
 }
 
 async function readHeatingGpioUncached(heatingPiIp: string): Promise<HeatingGpioSnapshot | undefined> {


### PR DESCRIPTION
The review-response commit for the auto-review on #42 (it was meant to land there but missed the merge):

- Element-only cache primes keep the previous `atMs` — a write can't extend the stove reading's effective age indefinitely.
- GPIO broadcasts prime the full outputs snapshot (`primeHeatingGpioFromBroadcast`) — they always carried the fresh stove state; now it's used instead of discarded. The redundant prime on the read-path removed.
- `shouldSubtractElpatronHistory` extracted so planPreview cannot drift from buildPlannerInput.
- Selftest imports `MANUAL_ON_MODEL_HORIZON_MS` instead of re-hardcoding 24 h; `estimateElpatronHistory` docstring updated to the stove-gated reality.

Typecheck + all 52 selftest checks green on this exact tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gnx4sUB71SzTnG5iP5dcZN