### PR TITLE
Elpatron history: boiler fingerprint from tank data, drop the stove gate

### DIFF
--- a/backend/src/autoTrading/autoTrader.ts
+++ b/backend/src/autoTrading/autoTrader.ts
@@ -10,7 +10,7 @@ import { inverterIdleWatts, packCapacityWh } from "../battery/ahLedgerDerivedVal
 import { fetchPrices, type FetchedPrices, getCachedPrices } from "./priceService.ts";
 import { fetchSolarForecast } from "./solarForecast.ts";
 import { fetchConsumptionForecast } from "./consumptionForecast.ts";
-import { fetchElpatronForecast, shouldSubtractElpatronHistory } from "./elpatronForecast.ts";
+import { fetchElpatronForecast } from "./elpatronForecast.ts";
 import {
   type AutoTraderState,
   type AutoTraderStatus,
@@ -351,7 +351,7 @@ async function buildPlannerInput(
   const consumption = await fetchConsumptionForecast(
     ctx.influxClient(),
     tradingConfig.fallback_house_load_watts,
-    shouldSubtractElpatronHistory(elpatron) ? cfg.elpatron_switching : undefined
+    cfg.elpatron_switching
   );
   const { sells, buys } = userWindows(ctx, cfg);
   return {

--- a/backend/src/autoTrading/consumptionForecast.ts
+++ b/backend/src/autoTrading/consumptionForecast.ts
@@ -31,13 +31,11 @@ function localHour(ms: number): number {
  * Median over days is used so that rare heavy loads (EV charging sessions) don't inflate the baseline —
  * those are exactly what the user handles manually via the extra-reserve knob.
  *
- * When `subtractElpatron` is set (the pellet stove is off, so the element is the tank's only heat
- * source — the caller gates on live stove state, see buildPlannerInput), the element's share is
- * stripped from each historical hour, using the tank sensor: energy into the tank ≈ heat capacity
- * × (ΔT + standing loss). The forward model adds the element back whenever it's armed, so leaving
- * it in the baseline would double-count it — and element days linger in this 14-day window after
- * disarming, which is why the gate is the stove, not the element's current armed state.
- * Not applied in stove season, where tank warming is the boiler's doing.
+ * The water heater element's share is stripped from each historical hour using the tank sensor
+ * (see estimateElpatronWattsByHour) — the forward model adds the element back whenever it's
+ * armed, so leaving it in the baseline would double-count it, and element days linger in this
+ * 14-day window after disarming. The subtraction runs unconditionally: it self-gates per hour by
+ * detecting boiler-heated hours from the tank data itself, so stove season degrades to a no-op.
  */
 export async function fetchConsumptionForecast(
   influxClient: Influx.InfluxDB | undefined,
@@ -122,16 +120,6 @@ export async function fetchConsumptionForecast(
   return cache;
 }
 
-/**
- * Estimate the element's average watts for each historical hour from the tank sensor: energy in ≈
- * tank_wh_per_degree × (temperature rise + what standing loss ate). Hot-water usage hours show a
- * steep temperature DROP and clamp to 0; hours holding the thermostat band land near the standing
- * loss — both are what actually happened electrically, to within the calibration.
- *
- * Assumes the element is the ONLY thing heating the tank. The caller guarantees that by gating
- * on the stove GPIO being off (shouldSubtractElpatronHistory); only the unknown-stove-state
- * fallback (heating pi unreachable ⇒ gate on armed) still leans on armed-implies-stove-cold.
- */
 async function estimateElpatronHistory(
   influxClient: Influx.InfluxDB,
   knobs: ElpatronHistoryKnobs,
@@ -142,23 +130,62 @@ async function estimateElpatronHistory(
       `SELECT mean(akkumulator) as tank FROM "frendebo_thermometers" WHERE time > now() - 14d GROUP BY time(1h)`
     )
   )) as unknown as { time: { getNanoTime(): number }; tank: number | null }[];
-  const hourMs = 3600 * 1000;
   const tankByMs = new Map<number, number>();
   for (const row of rows) {
     if (row.tank == null) continue;
     tankByMs.set(Math.round(row.time.getNanoTime() / 1e6), row.tank);
   }
+  return estimateElpatronWattsByHour(tankByMs, knobs);
+}
+
+/**
+ * Estimate the element's average watts for each historical hour from the tank sensor: energy in ≈
+ * tank_wh_per_degree × (temperature rise + what standing loss ate). Hot-water usage hours show a
+ * steep temperature DROP and clamp to 0; hours holding the thermostat band land near the standing
+ * loss — both are what actually happened electrically, to within the calibration.
+ *
+ * The element is NOT assumed to be the only heat source — the pellet boiler is detected and its
+ * hours excluded via a physics fingerprint on the same data: the element's thermostat cuts around
+ * tank_max_temperature (observed maxima ≤ ~56 °C) and it can't heat the sensor faster than
+ * ~12 °C/h, while boiler firings push to 62–70 °C at 8–19 °C/h (measured 2026-06-16..18). Any
+ * sample above tank_max + 2 marks its ±6 h neighbourhood as boiler-heated (firings rise through
+ * the element's band on the way up and coast back down through it for hours), and an
+ * implausibly-fast rise is excluded on its own. In deep stove season the daily firings blanket
+ * the whole window, so the subtraction self-disables without any signal from the heating pi —
+ * its stove GPIO turned out to be a call-for-heat line (asserted all summer) and its
+ * stove_disabled config flag flips with operator fiddling, so neither is trusted here.
+ *
+ * Pure and exported for the selftest.
+ */
+export function estimateElpatronWattsByHour(
+  tankByMs: Map<number, number>,
+  knobs: ElpatronHistoryKnobs
+): Map<number, number> {
+  const hourMs = 3600 * 1000;
+  const boilerTemperatureC = knobs.tank_max_temperature + 2;
+  const maxElementRiseDegreesPerHour = 15;
+  const boilerNeighbourhoodHours = 6;
+
+  const boilerContaminatedMs = new Set<number>();
+  for (const [ms, tank] of tankByMs) {
+    if (tank <= boilerTemperatureC) continue;
+    for (let offset = -boilerNeighbourhoodHours; offset <= boilerNeighbourhoodHours; offset++) {
+      boilerContaminatedMs.add(ms + offset * hourMs);
+    }
+  }
+
   const elpatronWByMs = new Map<number, number>();
   for (const [ms, tank] of tankByMs) {
     const nextTank = tankByMs.get(ms + hourMs);
     if (nextTank === undefined) continue;
     const deltaDegrees = nextTank - tank;
+    const boilerHeated = boilerContaminatedMs.has(ms) || deltaDegrees > maxElementRiseDegreesPerHour;
     // The standing-loss term only belongs to hours the element could have been compensating it:
     // a rising tank, or a flat one held near the thermostat band. A tank coasting well below the
     // band cools slower than the (hot-tank-calibrated) constant, and crediting the difference to
     // the element invented a few hundred phantom watts on quiet nights — enough to out-dominate
     // a small house load and get real samples dropped.
-    const elementCouldBeActive = deltaDegrees > 0 || tank >= knobs.tank_max_temperature - 5;
+    const elementCouldBeActive = !boilerHeated && (deltaDegrees > 0 || tank >= knobs.tank_max_temperature - 5);
     const estimatedW = elementCouldBeActive
       ? knobs.tank_wh_per_degree * (deltaDegrees + knobs.tank_cooling_degrees_per_hour)
       : 0;

--- a/backend/src/autoTrading/consumptionForecast.ts
+++ b/backend/src/autoTrading/consumptionForecast.ts
@@ -155,6 +155,13 @@ async function estimateElpatronHistory(
  * its stove GPIO turned out to be a call-for-heat line (asserted all summer) and its
  * stove_disabled config flag flips with operator fiddling, so neither is trusted here.
  *
+ * Residual risks, for the record: a PARTIAL firing that never crests tank_max + 2 and rises
+ * ≤15 °C/h would be subtracted as element — the one misclassification that UNDER-forecasts
+ * (all others over-forecast, the safe direction). Real firings reach 62–70 °C, so this is the
+ * tail case. And tank_max_temperature does double duty as the element band edge (−5) and the
+ * boiler ceiling (+2): recalibrating it moves both, which at worst mislabels element burns as
+ * boiler (safe direction, element stays in the baseline).
+ *
  * Pure and exported for the selftest.
  */
 export function estimateElpatronWattsByHour(

--- a/backend/src/autoTrading/elpatronForecast.ts
+++ b/backend/src/autoTrading/elpatronForecast.ts
@@ -13,7 +13,7 @@
 
 import Influx from "influx";
 import { warnLog } from "../utilities/logging.ts";
-import { readHeatingGpio } from "../utilities/heatingPi.ts";
+import { readElpatronGpioIsOn } from "../utilities/heatingPi.ts";
 import { resolveElpatronMode } from "../sharedTypes.ts";
 import type { Config } from "../config/config.types.ts";
 
@@ -22,12 +22,6 @@ export type ElpatronForecast = {
   wattsAt: (ms: number) => number;
   armed: boolean;
   tankTempC: number | undefined;
-  /**
-   * Whether the pellet stove output is on (undefined = heating pi unreachable). While the stove
-   * is definitely off, the element is the tank's only heat source — which is what licenses the
-   * consumption history subtraction regardless of the element's current armed state.
-   */
-  stoveOn: boolean | undefined;
 };
 
 /**
@@ -38,17 +32,6 @@ export type ElpatronForecast = {
  * Exported for the selftest so a changed horizon is tested, not a stale copy.
  */
 export const MANUAL_ON_MODEL_HORIZON_MS = 24 * 3600 * 1000;
-
-/**
- * Whether the learned-baseline subtraction may run (see consumptionForecast.ts): while the pellet
- * stove is definitely off, the element is the tank's only heat source, so its historical share is
- * strippable regardless of the element's CURRENT armed state — element days linger in the 14-day
- * median after disarming. Unknown stove state (heating pi unreachable) falls back to the armed
- * gate, which is safe in both seasons. One helper so the planner and planPreview cannot drift.
- */
-export function shouldSubtractElpatronHistory(elpatron: Pick<ElpatronForecast, "armed" | "stoveOn">): boolean {
-  return elpatron.stoveOn === false || (elpatron.stoveOn === undefined && elpatron.armed);
-}
 
 export async function fetchElpatronForecast({
   elpatronConfig,
@@ -61,12 +44,11 @@ export async function fetchElpatronForecast({
   solarWattsAt: (ms: number) => number;
   nowMs: number;
 }): Promise<ElpatronForecast> {
-  // Always read the gpio: even with a switching mode active (armed either way), the stove state
-  // decides whether the history subtraction may run
-  const gpio = await readHeatingGpio(elpatronConfig.heating_pi_ip);
+  // Armed = we actively switch it (solar or always-on mode), or someone left the element GPIO
+  // on manually — that last case is only knowable by asking the heating pi
   const elpatronMode = resolveElpatronMode(elpatronConfig);
-  const armed = elpatronMode !== "off" || gpio?.elementOn === true;
-  if (!armed) return { wattsAt: () => 0, armed: false, tankTempC: undefined, stoveOn: gpio?.stoveOn };
+  const armed = elpatronMode !== "off" || (await readElpatronGpioIsOn(elpatronConfig.heating_pi_ip)) === true;
+  if (!armed) return { wattsAt: () => 0, armed: false, tankTempC: undefined };
 
   const tankTempC = await fetchTankTemperature(influxClient);
   // Without a tank reading, assume mid-band: still predicts a plausible dawn burn + top-ups
@@ -87,7 +69,7 @@ export async function fetchElpatronForecast({
     tank_cooling_degrees_per_hour: elpatronConfig.tank_cooling_degrees_per_hour,
     tank_max_temperature: elpatronConfig.tank_max_temperature,
   });
-  return { wattsAt, armed: true, tankTempC, stoveOn: gpio?.stoveOn };
+  return { wattsAt, armed: true, tankTempC };
 }
 
 /**

--- a/backend/src/autoTrading/planPreview.ts
+++ b/backend/src/autoTrading/planPreview.ts
@@ -16,7 +16,7 @@ import { inverterIdleWatts, packCapacityWh } from "../battery/ahLedgerDerivedVal
 import { fetchPrices } from "./priceService.ts";
 import { fetchSolarForecast } from "./solarForecast.ts";
 import { fetchConsumptionForecast } from "./consumptionForecast.ts";
-import { fetchElpatronForecast, shouldSubtractElpatronHistory } from "./elpatronForecast.ts";
+import { fetchElpatronForecast } from "./elpatronForecast.ts";
 import { generatePlan } from "./planner.ts";
 import type { PlannerInput } from "./planner.types.ts";
 
@@ -60,13 +60,9 @@ const elpatron = await fetchElpatronForecast({
   nowMs: Date.now(),
 });
 console.log(
-  `Elpatron: ${elpatron.armed ? `armed, tank ${elpatron.tankTempC ?? "?"}°C — modeled as known load` : "not armed"}, stove on: ${elpatron.stoveOn ?? "unknown"}\n`
+  `Elpatron: ${elpatron.armed ? `armed, tank ${elpatron.tankTempC ?? "?"}°C — modeled as known load` : "not armed"}\n`
 );
-const consumption = await fetchConsumptionForecast(
-  influxClient,
-  at.fallback_house_load_watts,
-  shouldSubtractElpatronHistory(elpatron) ? elpatronConfig : undefined
-);
+const consumption = await fetchConsumptionForecast(influxClient, at.fallback_house_load_watts, elpatronConfig);
 
 const fixedSells = Object.entries(config.scheduled_power_selling.schedule)
   .map(([start, e]) => ({ startMs: +new Date(start), endMs: +new Date(e.end_time), watts: Number(e.power_watts) }))

--- a/backend/src/autoTrading/planner.selftest.ts
+++ b/backend/src/autoTrading/planner.selftest.ts
@@ -6,6 +6,7 @@ import { generatePlan, projectWithFixedWindows, SLOT_MS } from "./planner.ts";
 import { fitSolarModel, fitIsPlausibleVsCurrent } from "./solarCalibration.ts";
 import { computeRealizedRevenue } from "./tradingPerformance.ts";
 import { buildElpatronLoadModel, MANUAL_ON_MODEL_HORIZON_MS } from "./elpatronForecast.ts";
+import { estimateElpatronWattsByHour } from "./consumptionForecast.ts";
 import type { PlannerInput } from "./planner.types.ts";
 
 const H = 3600_000;
@@ -613,6 +614,55 @@ function check(name: string, cond: boolean, detail = "") {
   });
   check("elpatron: manual-on modeled within the first day", manual(t0 + 20 * H) === 480);
   check("elpatron: manual-on not extrapolated past a day", manual(t0 + 30 * H) === 0, `(${manual(t0 + 30 * H)} W)`);
+}
+
+// ---------- Scenario 14: elpatron history estimator — element fingerprint vs pellet boiler ----------
+// The estimator must attribute element burns (≤ ~12 °C/h, capped ~55 °C) and band-holding hours,
+// but nothing to coasting far below the band, and nothing to boiler firings (> 57 °C peaks, up to
+// 19 °C/h) or the hours around them — including the post-firing dwell back through the element's
+// band, which would otherwise be credited phantom maintenance.
+{
+  const estimatorKnobs = {
+    element_watts: 6200,
+    tank_wh_per_degree: 480,
+    tank_cooling_degrees_per_hour: 1,
+    tank_max_temperature: 55,
+  };
+  const tankAtHour: [number, number][] = [
+    [0, 36],
+    [1, 35.6],
+    [2, 35.2],
+    [3, 34.8],
+    [4, 34.4],
+    [5, 34], // slow coast far below band
+    [6, 34],
+    [7, 45],
+    [8, 54],
+    [9, 55],
+    [10, 54.5],
+    [11, 54], // element burn then thermostat band
+    [29, 45.5],
+    [30, 45],
+    [31, 60],
+    [32, 66],
+    [33, 58], // boiler firing: +15 °C/h to 66
+    [34, 56.5],
+    [35, 55.8],
+    [36, 55.2],
+    [37, 54.6], // post-firing dwell back through the band
+  ];
+  const tankByMs = new Map(tankAtHour.map(([hour, temperature]) => [t0 + hour * H, temperature]));
+  const estimate = estimateElpatronWattsByHour(tankByMs, estimatorKnobs);
+  const atHour = (hour: number) => estimate.get(t0 + hour * H);
+  check("history: slow coast far below band attributes nothing", atHour(2) === 0, `(${atHour(2)} W)`);
+  check("history: element burn attributed at ~full power", (atHour(6) ?? 0) > 5000, `(${atHour(6)} W)`);
+  check("history: band-holding hour credited the standing loss", atHour(10) === 240, `(${atHour(10)} W)`);
+  check(
+    "history: boiler firing attributes nothing",
+    atHour(30) === 0 && atHour(31) === 0,
+    `(${atHour(30)}/${atHour(31)} W)`
+  );
+  check("history: post-firing dwell in the band attributes nothing", atHour(34) === 0, `(${atHour(34)} W)`);
 }
 
 console.log(fails.length ? `\n${fails.length} FAILURES: ${fails.join(", ")}` : "\nAll scenarios passed");

--- a/backend/src/elpatronSwitching.ts
+++ b/backend/src/elpatronSwitching.ts
@@ -3,12 +3,7 @@ import { random_string, wait } from "./vendor/depictUtilishared.ts";
 import { useTotalSolarPower } from "./utilities/useTotalSolarPower.ts";
 import { useFromMqttProvider } from "./mqttValues/MQTTValuesProvider.ts";
 import { reactiveBatteryVoltage } from "./mqttValues/mqttHelpers.ts";
-import {
-  getHeatingPiSocket,
-  primeElpatronGpioCache,
-  primeHeatingGpioFromBroadcast,
-  readElpatronGpioIsOn,
-} from "./utilities/heatingPi.ts";
+import { getHeatingPiSocket, primeElpatronGpioCache, readElpatronGpioIsOn } from "./utilities/heatingPi.ts";
 import { logLog, warnLog } from "./utilities/logging.ts";
 import { type ElpatronDisplayState, type ElpatronMode, resolveElpatronMode } from "./sharedTypes.ts";
 import type { DepictAPIWS } from "./vendor/depictUtilishared.ts";
@@ -96,9 +91,8 @@ export function elpatronSwitching(config: Accessor<Config>) {
         if (decoded?.type !== "change" || decoded.key !== "gpio") return;
         const outputs = decoded.value?.outputs;
         if (outputs?.electric_heating_element === undefined) return;
-        // The broadcast carries every output's fresh state — including the stove, which the
-        // consumption model's subtraction gate reads
-        primeHeatingGpioFromBroadcast(ip, outputs);
+        // The broadcast carries the element's fresh state — cache it as just-observed
+        primeElpatronGpioCache(ip, outputs.electric_heating_element === 0);
         applyState(outputs.electric_heating_element === 0); // active-low
       } catch (e) {
         warnLog("Elpatron: couldn't parse heating pi broadcast", e);

--- a/backend/src/utilities/heatingPi.ts
+++ b/backend/src/utilities/heatingPi.ts
@@ -23,68 +23,38 @@ export function getHeatingPiSocket(heatingPiIp: string): DepictAPIWS {
   return socket;
 }
 
-/** Both pins are active-low (raw 0 = powered); undefined = the output was missing in the reply */
-export type HeatingGpioSnapshot = { elementOn: boolean | undefined; stoveOn: boolean | undefined };
-
-let gpioReadCache: { heatingPiIp: string; atMs: number; value: HeatingGpioSnapshot | undefined } | undefined;
+let gpioReadCache: { heatingPiIp: string; atMs: number; value: boolean | undefined } | undefined;
 
 /**
- * Current heating-pi output states: the water heater element and the pellet stove (the latter
- * tells the consumption model whether the element can be assumed to be the tank's only heat
- * source). Returns undefined when the heating pi doesn't answer in time — ensure_sent retries
- * forever, and a plan run must not hang on an unreachable pi in another building. Results
- * (including failures) are cached (default 10 minutes) so the guard's 15-min ticks don't hammer
- * or stall on the pi; the frontend's live state poll passes a shorter maxAge.
+ * Whether the element GPIO is currently on (the pin is active-low: raw 0 = element powered).
+ * Returns undefined when the heating pi doesn't answer in time — ensure_sent retries forever, and
+ * a plan run must not hang on an unreachable pi in another building. Results (including failures)
+ * are cached (default 10 minutes) so the guard's 15-min ticks don't hammer or stall on the pi;
+ * the frontend's live state poll passes a shorter maxAge.
+ *
+ * Only the element is read here. The stove GPIO deliberately is NOT a signal for anything: it
+ * turned out to be a call-for-heat line that sits asserted all summer (tank below the boiler's
+ * setpoint), not a "boiler is heating" indicator — boiler detection lives in the tank-data
+ * fingerprint in consumptionForecast.ts instead.
  */
-export async function readHeatingGpio(
-  heatingPiIp: string,
-  maxAgeMs = 10 * 60_000
-): Promise<HeatingGpioSnapshot | undefined> {
+export async function readElpatronGpioIsOn(heatingPiIp: string, maxAgeMs = 10 * 60_000): Promise<boolean | undefined> {
   if (gpioReadCache && gpioReadCache.heatingPiIp === heatingPiIp && Date.now() - gpioReadCache.atMs < maxAgeMs) {
     return gpioReadCache.value;
   }
-  const value = await readHeatingGpioUncached(heatingPiIp);
+  const value = await readElpatronGpioUncached(heatingPiIp);
   gpioReadCache = { heatingPiIp, atMs: Date.now(), value };
   return value;
 }
 
-/** Whether the element GPIO is currently on. See readHeatingGpio for semantics and caching. */
-export async function readElpatronGpioIsOn(heatingPiIp: string, maxAgeMs = 10 * 60_000): Promise<boolean | undefined> {
-  return (await readHeatingGpio(heatingPiIp, maxAgeMs))?.elementOn;
-}
-
 /**
- * After we wrote the element GPIO ourselves the element state is known — spare the next reader a
- * roundtrip. Only updates the element within the cache's existing freshness window: the carried
- * stove state was NOT just observed, so a write must not extend the snapshot's age (else frequent
- * element flips could postpone a real stove read indefinitely).
+ * After we wrote the element GPIO ourselves — or a heating-pi broadcast reported it — the state
+ * is just-observed: cache it and spare the next reader a roundtrip.
  */
 export function primeElpatronGpioCache(heatingPiIp: string, isOn: boolean) {
-  const previous = gpioReadCache?.heatingPiIp === heatingPiIp ? gpioReadCache : undefined;
-  gpioReadCache = {
-    heatingPiIp,
-    atMs: previous?.atMs ?? 0,
-    value: { elementOn: isOn, stoveOn: previous?.value?.stoveOn },
-  };
+  gpioReadCache = { heatingPiIp, atMs: Date.now(), value: isOn };
 }
 
-/**
- * A {type:"change", key:"gpio"} broadcast from the heating pi carries the fresh state of ALL
- * outputs — cache the full snapshot as just-observed.
- */
-export function primeHeatingGpioFromBroadcast(heatingPiIp: string, outputs: Record<string, number>) {
-  if (outputs.electric_heating_element === undefined) return;
-  gpioReadCache = {
-    heatingPiIp,
-    atMs: Date.now(),
-    value: {
-      elementOn: outputs.electric_heating_element === 0,
-      stoveOn: outputs.stove === undefined ? undefined : outputs.stove === 0,
-    },
-  };
-}
-
-async function readHeatingGpioUncached(heatingPiIp: string): Promise<HeatingGpioSnapshot | undefined> {
+async function readElpatronGpioUncached(heatingPiIp: string): Promise<boolean | undefined> {
   const socket = getHeatingPiSocket(heatingPiIp);
   const request = socket.ensure_sent({ id: random_string(), command: "read", key: "gpio" }) as Promise<
     [{ status: string; value?: { outputs?: Record<string, number> } }, unknown]
@@ -95,13 +65,10 @@ async function readHeatingGpioUncached(heatingPiIp: string): Promise<HeatingGpio
     warnLog("Heating pi: gpio read failed or timed out", heatingPiIp, result);
     return undefined;
   }
-  const outputs = result.value?.outputs;
-  if (outputs?.electric_heating_element === undefined) {
+  const rawState = result.value?.outputs?.electric_heating_element;
+  if (rawState === undefined) {
     warnLog("Heating pi: gpio response has no electric_heating_element output", result.value);
     return undefined;
   }
-  return {
-    elementOn: outputs.electric_heating_element === 0,
-    stoveOn: outputs.stove === undefined ? undefined : outputs.stove === 0,
-  };
+  return rawState === 0;
 }


### PR DESCRIPTION
Post-deploy verification of #42/#43 caught the stove-GPIO gate being wrong in practice: a direct ws probe showed `outputs.stove: 0` with a **cold boiler in July** (`feeder_protection_triggered: true`) — the pin is a call-for-heat/enable line asserted whenever the tank is below the boiler's setpoint, not a "boiler is burning" indicator. The heating pi's `stove_disabled` config flag is no better (it read `true` on Jul 10 and `false` today, tracking operator fiddling). With the shipped gate, the history subtraction would have silently never run all summer.

## The replacement: physics fingerprint on data we already trust

Boiler detection moves into the tank series itself, calibrated against the June 16–18 firings:

- The element's thermostat cuts at ~55–56 °C at our sensor and can't heat faster than ~12 °C/h.
- Boiler firings push to 62–70 °C at 8–19 °C/h.

Any sample above `tank_max_temperature + 2` marks its **±6 h neighbourhood** as boiler-heated (covers the rise through the element's band on the way up and the hours-long coast back down through it — which would otherwise earn phantom standing-loss credit), and an implausibly fast rise (>15 °C/h) is excluded on its own. Rate alone doesn't separate them (ranges overlap); the temperature ceiling does, with the neighbourhood handling transition hours.

The subtraction now runs **unconditionally** and self-gates per hour: in deep stove season, daily firings blanket the whole 14-day window and it degrades to a no-op — season detection with zero dependency on the heating pi's API/semantics. `shouldSubtractElpatronHistory` and the stove-snapshot cache machinery are reverted (element-only gpio cache, fresh-stamped primes — correct again now that the cache holds only the just-observed element pin).

## Validation

- Estimator core extracted pure (`estimateElpatronWattsByHour`) with 5 new selftest checks: element burn attributed at full power, band-holding hour credited the standing loss, slow coast far below the band → 0, boiler firing → 0, post-firing dwell through the band → 0. All 59 checks green, typecheck clean.
- Live preview: element currently off (mode fiddling in progress on the live system) and the subtraction **still runs** — clean residual profile (night 190–260 W, evening peak intact), which is precisely the post-disarm re-inflation this line of work set out to kill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gnx4sUB71SzTnG5iP5dcZN