### PR TITLE
Drop dead config keys (#45 fallout) + delete unused temperature_report_interval

### DIFF
--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -138,7 +138,6 @@ export const default_config: Config = {
   mqtt_host: "192.168.0.3",
   stop_charging_below_current: 10,
   thermometers: {},
-  temperature_report_interval: 3000,
   temperature_saving: {
     database: "mppsolar",
     table: "battery_temperatures",

--- a/backend/src/config/config.types.ts
+++ b/backend/src/config/config.types.ts
@@ -242,7 +242,6 @@ export type Config = {
   full_battery_voltage: number;
   float_charging_voltage: number;
   start_bulk_charge_voltage: number;
-  temperature_report_interval: number;
   thermometers: { [key: string]: string };
   mqtt_host: string;
   temperature_saving: {

--- a/backend/src/config/configPatch.ts
+++ b/backend/src/config/configPatch.ts
@@ -92,18 +92,11 @@ const TOP_LEVEL_CONFIG_KEYS = {
   full_battery_voltage: true,
   float_charging_voltage: true,
   start_bulk_charge_voltage: true,
-  temperature_report_interval: true,
   thermometers: true,
   mqtt_host: true,
   temperature_saving: true,
   feed_from_battery_when_no_solar: true,
   start_bulk_charge_after_wh_discharged: true,
-  shinemonitor_password: true,
-  shinemonitor_user: true,
-  shinemonitor_company_key: true,
-  inverter_sn: true,
-  inverter_pn: true,
-  savedAuth_do_not_edit: true,
 } satisfies Record<keyof Config, true>;
 
 /**
@@ -128,11 +121,6 @@ const UNSETTABLE_PATH_PATTERNS: readonly (readonly string[])[] = [
   ["thermometers", "*"],
   ["elpatron_switching", "mode"],
   ["influxdb"],
-  ["shinemonitor_password"],
-  ["shinemonitor_user"],
-  ["inverter_sn"],
-  ["inverter_pn"],
-  ["savedAuth_do_not_edit"],
 ];
 
 /** Assigning these via bracket notation mutates the prototype chain instead of the object. */

--- a/backend/src/websocketBackend/mockConfigServer.ts
+++ b/backend/src/websocketBackend/mockConfigServer.ts
@@ -74,6 +74,5 @@ function seedConfig(): Config {
     "28-00000e8d0b6a": "Battery cell 3",
     "28-00000e8ddf12": "Cooling outlet left",
   };
-  seeded.shinemonitor_user = "daniel";
   return seeded;
 }

--- a/frontend/src/components/configEditor/configFieldMeta.ts
+++ b/frontend/src/components/configEditor/configFieldMeta.ts
@@ -61,9 +61,9 @@ export type ConfigSectionMeta = {
 };
 
 /** Top-level keys deliberately not rendered anywhere (with the reason shown to the user). */
-export const HIDDEN_TOP_LEVEL_KEYS: Record<string, string> = {
-  savedAuth_do_not_edit: "The saved ShineMonitor login token is managed automatically and is not editable here.",
-};
+// Currently empty — the ShineMonitor auth blob this existed for died with the cloud dependency.
+// Kept for the next machine-owned blob that should stay off the page (with its reason shown).
+export const HIDDEN_TOP_LEVEL_KEYS: Record<string, string> = {};
 
 const f = (
   path: readonly string[],
@@ -785,7 +785,7 @@ export const CONFIG_SECTIONS: readonly ConfigSectionMeta[] = [
     id: "thermometers",
     title: "Thermometers",
     description: "Names for the 1-wire temperature sensors and where their history goes.",
-    rootKeys: ["thermometers", "temperature_report_interval", "temperature_saving"],
+    rootKeys: ["thermometers", "temperature_saving"],
     fields: [
       f(
         ["thermometers"],
@@ -803,9 +803,6 @@ export const CONFIG_SECTIONS: readonly ConfigSectionMeta[] = [
           },
         }
       ),
-      f(["temperature_report_interval"], "Read interval", "How often temperatures are read and broadcast.", {
-        unit: "ms",
-      }),
       f(["temperature_saving", "database"], "History database", "InfluxDB database temperature history is written to."),
       f(["temperature_saving", "table"], "History table", "InfluxDB table temperature history is written to."),
     ],
@@ -814,16 +811,7 @@ export const CONFIG_SECTIONS: readonly ConfigSectionMeta[] = [
     id: "connections",
     title: "Inverter & connections",
     description: "How the controller talks to the inverter and the outside world. Rarely touched.",
-    rootKeys: [
-      "usb_parameter_setting",
-      "mqtt_host",
-      "shinemonitor_user",
-      "shinemonitor_password",
-      "shinemonitor_company_key",
-      "inverter_sn",
-      "inverter_pn",
-      "savedAuth_do_not_edit",
-    ],
+    rootKeys: ["usb_parameter_setting", "mqtt_host"],
     fields: [
       f(
         ["usb_parameter_setting", "min_seconds_between_commands"],
@@ -838,13 +826,6 @@ export const CONFIG_SECTIONS: readonly ConfigSectionMeta[] = [
         { unit: "s" }
       ),
       f(["mqtt_host"], "MQTT broker", "Host publishing the inverter telemetry the controller consumes."),
-      f(["shinemonitor_user"], "ShineMonitor user", "Cloud login used to set inverter parameters remotely.", {
-        heading: "ShineMonitor cloud",
-      }),
-      f(["shinemonitor_password"], "ShineMonitor password", "Cloud login password.", { secret: true }),
-      f(["shinemonitor_company_key"], "Company key", "Vendor constant for the ShineMonitor API."),
-      f(["inverter_sn"], "Inverter serial", "Auto-detected when blank."),
-      f(["inverter_pn"], "Inverter part number", "Auto-detected when blank."),
     ],
   },
   {

--- a/frontend/src/helpers/configPatches.ts
+++ b/frontend/src/helpers/configPatches.ts
@@ -41,11 +41,7 @@ type UnsettableConfigPath =
   | readonly ["scheduled_power_buying", "schedule", string]
   | readonly ["thermometers", string]
   | readonly ["elpatron_switching", "mode"]
-  | readonly ["influxdb"]
-  | readonly ["shinemonitor_password"]
-  | readonly ["shinemonitor_user"]
-  | readonly ["inverter_sn"]
-  | readonly ["inverter_pn"];
+  | readonly ["influxdb"];
 
 export function configUnset(path: UnsettableConfigPath): ConfigPatch {
   return { path, op: "unset" };


### PR DESCRIPTION
Two things, both fallout of config keys that no longer exist:

1. **Unbreak main's typecheck.** #46 merged after #45 removed `shinemonitor_*`, `inverter_sn/pn` and `savedAuth_do_not_edit` from the Config type (my PR's CI ran against the pre-#45 base, textual merge was clean — semantic skew). Removes them from configPatch's `satisfies`-checked key list + unset allowlist, the frontend unset union, the config-page meta (ShineMonitor group, hidden-key note) and the mock server seed.

2. **Delete `temperature_report_interval` end-to-end** (type, default, key list, config-page field). Nothing reads it: `useTemperatures` polls each sensor as fast as the 1-wire bus allows and `saveTemperatures` reports on change. The config page's help text ("how often temperatures are read and broadcast") was describing a knob that does nothing — deleting beats documenting.

Live configs still carrying these keys are unaffected (`mergeWithDefaults` spreads unknown keys through); they get cleaned out of the pi's `config.json` during rollout, after which the config page's "Uncategorized" orphan section disappears.

Gates: root typecheck clean again, 4/4 selftests, frontend build + `tsc --noEmit` clean, grep-proof zero references to the removed keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fy3TkmYf1sQVVLMqwJoyb7