### PR TITLE
planner: descriptive names (follow-up to review comments on #30)

### DIFF
--- a/backend/src/autoTrading/planner.ts
+++ b/backend/src/autoTrading/planner.ts
@@ -35,12 +35,12 @@ import type {
 export const SLOT_MS = 15 * 60 * 1000;
 
 export function generatePlan(input: PlannerInput): PlanResult {
-  const k = input.knobs;
+  const knobs = input.knobs;
   const notes: string[] = [];
   const slots = buildSlots(input);
   const cap = input.capacityWh;
 
-  const pricedSlots = slots.filter(s => s.spot !== undefined);
+  const pricedSlots = slots.filter(slot => slot.spot !== undefined);
   if (!pricedSlots.length) {
     return {
       sells: [],
@@ -53,7 +53,7 @@ export function generatePlan(input: PlannerInput): PlanResult {
   // Conservative valuation for the unpriced constraint tail: median of the last priced day
   const lastDaySpots = pricedSlots
     .slice(-96)
-    .map(s => s.spot!)
+    .map(slot => slot.spot!)
     .sort((a, b) => a - b);
   const tailSpot = lastDaySpots[Math.floor(lastDaySpots.length / 2)] ?? 0.5;
 
@@ -61,25 +61,27 @@ export function generatePlan(input: PlannerInput): PlanResult {
   const buyW = new Array(slots.length).fill(0);
 
   const base = simulate(input, slots, sellW, buyW, tailSpot);
-  const feasibleVsBase = (r: SimResult) => r.violationWh <= base.violationWh + 1;
+  const feasibleVsBase = (result: SimResult) => result.violationWh <= base.violationWh + 1;
 
   // ---- Greedy sell allocation, highest spot first ----
   const sellCandidates = slots
-    .map((s, i) => ({ s, i }))
-    .filter(({ s }) => slotTradableForSell(s, input.sellVetoWindows) && s.spot! >= k.min_sell_spot_sek_per_kwh)
-    .sort((a, b) => b.s.spot! - a.s.spot!);
+    .map((slot, slotIndex) => ({ slot, slotIndex }))
+    .filter(
+      ({ slot }) => slotTradableForSell(slot, input.sellVetoWindows) && slot.spot! >= knobs.min_sell_spot_sek_per_kwh
+    )
+    .sort((a, b) => b.slot.spot! - a.slot.spot!);
 
   let current = base;
   const acceptedSell: number[] = [];
-  for (const { i } of sellCandidates) {
-    sellW[i] = k.max_sell_power_watts;
+  for (const { slotIndex } of sellCandidates) {
+    sellW[slotIndex] = knobs.max_sell_power_watts;
     const trial = simulate(input, slots, sellW, buyW, tailSpot);
     const gain = trial.revenueSek - current.revenueSek;
-    if (feasibleVsBase(trial) && gain >= k.min_gain_sek_per_slot) {
+    if (feasibleVsBase(trial) && gain >= knobs.min_gain_sek_per_slot) {
       current = trial;
-      acceptedSell.push(i);
+      acceptedSell.push(slotIndex);
     } else {
-      sellW[i] = 0;
+      sellW[slotIndex] = 0;
     }
   }
 
@@ -107,7 +109,7 @@ export function generatePlan(input: PlannerInput): PlanResult {
         fillable.push(j);
       }
       if (fillable.length !== gapSlots) continue;
-      for (const j of fillable) sellW[j] = k.max_sell_power_watts;
+      for (const j of fillable) sellW[j] = knobs.max_sell_power_watts;
       const trial = simulate(input, slots, sellW, buyW, tailSpot);
       if (feasibleVsBase(trial) && trial.revenueSek - current.revenueSek >= -maxSmoothingLossSekPerSlot * gapSlots) {
         current = trial;
@@ -127,28 +129,31 @@ export function generatePlan(input: PlannerInput): PlanResult {
 
   // ---- Buy allocation, pass 1: avert projected unavoidable imports, cheapest slots first ----
   const acceptedBuy: number[] = [];
-  if (current.importWh > 500 && k.max_buy_power_watts > 0) {
+  if (current.importWh > 500 && knobs.max_buy_power_watts > 0) {
     notes.push(
       `Projected unavoidable import of ${(current.importWh / 1000).toFixed(1)} kWh — evaluating pre-buying at cheap hours`
     );
     const buyCandidates = slots
-      .map((s, i) => ({ s, i }))
+      .map((slot, slotIndex) => ({ slot, slotIndex }))
       .filter(
-        ({ s, i }) =>
-          s.spot !== undefined && s.fixedSellW === 0 && sellW[i] === 0 && !overlapsVeto(s, input.buyVetoWindows)
+        ({ slot, slotIndex }) =>
+          slot.spot !== undefined &&
+          slot.fixedSellW === 0 &&
+          sellW[slotIndex] === 0 &&
+          !overlapsVeto(slot, input.buyVetoWindows)
       )
-      .sort((a, b) => a.s.spot! - b.s.spot!);
-    for (const { i } of buyCandidates) {
-      if (sellW[i] > 0) continue;
-      buyW[i] = k.max_buy_power_watts;
+      .sort((a, b) => a.slot.spot! - b.slot.spot!);
+    for (const { slotIndex } of buyCandidates) {
+      if (sellW[slotIndex] > 0) continue;
+      buyW[slotIndex] = knobs.max_buy_power_watts;
       const trial = simulate(input, slots, sellW, buyW, tailSpot);
       const gain = trial.revenueSek - current.revenueSek;
       const extraBoughtKwh = (trial.boughtWh - current.boughtWh) / 1000;
-      if (feasibleVsBase(trial) && extraBoughtKwh > 0 && gain / extraBoughtKwh >= k.min_buy_saving_sek_per_kwh) {
+      if (feasibleVsBase(trial) && extraBoughtKwh > 0 && gain / extraBoughtKwh >= knobs.min_buy_saving_sek_per_kwh) {
         current = trial;
-        acceptedBuy.push(i);
+        acceptedBuy.push(slotIndex);
       } else {
-        buyW[i] = 0;
+        buyW[slotIndex] = 0;
       }
       if (current.importWh < 500) break;
     }
@@ -158,85 +163,89 @@ export function generatePlan(input: PlannerInput): PlanResult {
   // beats fees + VAT + round-trip losses + margin. Buys and sells only pay off together (bought
   // energy has no value without a later sell window), so they are trialled as pairs.
   const arbitrageBuySlots = new Set<number>();
-  if (k.allow_arbitrage_buying && k.max_buy_power_watts > 0) {
-    const roundTrip = k.charge_efficiency * k.discharge_efficiency;
-    const tradable = (i: number) =>
-      slots[i].spot !== undefined &&
-      sellW[i] === 0 &&
-      buyW[i] === 0 &&
-      slots[i].fixedSellW === 0 &&
-      slots[i].fixedBuyW === 0;
+  if (knobs.allow_arbitrage_buying && knobs.max_buy_power_watts > 0) {
+    const roundTrip = knobs.charge_efficiency * knobs.discharge_efficiency;
+    const tradable = (slotIndex: number) =>
+      slots[slotIndex].spot !== undefined &&
+      sellW[slotIndex] === 0 &&
+      buyW[slotIndex] === 0 &&
+      slots[slotIndex].fixedSellW === 0 &&
+      slots[slotIndex].fixedBuyW === 0;
     const buyPool = slots
-      .map((s, i) => ({ s, i }))
-      .filter(({ s, i }) => tradable(i) && !overlapsVeto(s, input.buyVetoWindows))
-      .sort((a, b) => a.s.spot! - b.s.spot!);
+      .map((slot, slotIndex) => ({ slot, slotIndex }))
+      .filter(({ slot, slotIndex }) => tradable(slotIndex) && !overlapsVeto(slot, input.buyVetoWindows))
+      .sort((a, b) => a.slot.spot! - b.slot.spot!);
     // A sold slot moves more energy out than one bought slot puts in (after losses), so a
     // 1:1 pairing is net-battery-negative and would always fail under a binding reserve floor.
     // Buy enough slots per sell slot to keep the pair battery-neutral or better.
-    const buySlotKwh = (k.max_buy_power_watts * 0.25) / 1000;
-    const sellSlotKwh = (Math.min(k.max_sell_power_watts, k.inverter_max_ac_output_watts) * 0.25) / 1000;
+    const buySlotKwh = (knobs.max_buy_power_watts * 0.25) / 1000;
+    const sellSlotKwh = (Math.min(knobs.max_sell_power_watts, knobs.inverter_max_ac_output_watts) * 0.25) / 1000;
     const buysPerSell = Math.max(1, Math.ceil(sellSlotKwh / (buySlotKwh * roundTrip)));
     let misses = 0;
     let pairs = 0;
     while (pairs < 60 && misses < 4) {
       const buyGroup: number[] = [];
-      for (const { i } of buyPool) {
-        if (tradable(i) && !buyGroup.includes(i)) buyGroup.push(i);
+      for (const { slotIndex } of buyPool) {
+        if (tradable(slotIndex) && !buyGroup.includes(slotIndex)) buyGroup.push(slotIndex);
         if (buyGroup.length === buysPerSell) break;
       }
       if (buyGroup.length < buysPerSell) break;
-      const lastBuyStart = Math.max(...buyGroup.map(i => slots[i].startMs));
+      const lastBuyStart = Math.max(...buyGroup.map(slotIndex => slots[slotIndex].startMs));
       const sellPool = slots
-        .map((s, i) => ({ s, i }))
+        .map((slot, slotIndex) => ({ slot, slotIndex }))
         .filter(
-          ({ s, i }) =>
-            tradable(i) &&
-            s.startMs > lastBuyStart &&
-            s.spot! >= k.min_sell_spot_sek_per_kwh &&
-            !overlapsVeto(s, input.sellVetoWindows)
+          ({ slot, slotIndex }) =>
+            tradable(slotIndex) &&
+            slot.startMs > lastBuyStart &&
+            slot.spot! >= knobs.min_sell_spot_sek_per_kwh &&
+            !overlapsVeto(slot, input.sellVetoWindows)
         )
-        .sort((a, b2) => b2.s.spot! - a.s.spot!);
+        .sort((a, b) => b.slot.spot! - a.slot.spot!);
       if (!sellPool.length) break;
       // Even the best possible pairing must clear the margin on prices alone, else nothing can
-      const avgBuySpot = buyGroup.reduce((sum, i) => sum + slots[i].spot!, 0) / buyGroup.length;
+      const avgBuySpot = buyGroup.reduce((sum, slotIndex) => sum + slots[slotIndex].spot!, 0) / buyGroup.length;
       const bestPossible =
-        (sellPool[0].s.spot! + k.sell_bonus_sek_per_kwh) * roundTrip -
-        (avgBuySpot + k.buy_surcharges_sek_per_kwh) * k.vat_multiplier;
-      if (bestPossible < k.min_buy_saving_sek_per_kwh) break;
+        (sellPool[0].slot.spot! + knobs.sell_bonus_sek_per_kwh) * roundTrip -
+        (avgBuySpot + knobs.buy_surcharges_sek_per_kwh) * knobs.vat_multiplier;
+      if (bestPossible < knobs.min_buy_saving_sek_per_kwh) break;
       let matched = false;
-      for (const { i: sellIdx } of sellPool.slice(0, 3)) {
-        for (const b of buyGroup) buyW[b] = k.max_buy_power_watts;
-        sellW[sellIdx] = k.max_sell_power_watts;
+      for (const { slotIndex: sellIndex } of sellPool.slice(0, 3)) {
+        for (const buyIndex of buyGroup) buyW[buyIndex] = knobs.max_buy_power_watts;
+        sellW[sellIndex] = knobs.max_sell_power_watts;
         const trial = simulate(input, slots, sellW, buyW, tailSpot);
         const gain = trial.revenueSek - current.revenueSek;
         const extraBoughtKwh = (trial.boughtWh - current.boughtWh) / 1000;
-        if (feasibleVsBase(trial) && extraBoughtKwh > 0.1 && gain / extraBoughtKwh >= k.min_buy_saving_sek_per_kwh) {
+        if (
+          feasibleVsBase(trial) &&
+          extraBoughtKwh > 0.1 &&
+          gain / extraBoughtKwh >= knobs.min_buy_saving_sek_per_kwh
+        ) {
           current = trial;
-          for (const b of buyGroup) {
-            acceptedBuy.push(b);
-            arbitrageBuySlots.add(b);
+          for (const buyIndex of buyGroup) {
+            acceptedBuy.push(buyIndex);
+            arbitrageBuySlots.add(buyIndex);
           }
-          acceptedSell.push(sellIdx);
+          acceptedSell.push(sellIndex);
           matched = true;
           pairs++;
           break;
         }
-        for (const b of buyGroup) buyW[b] = 0;
-        sellW[sellIdx] = 0;
+        for (const buyIndex of buyGroup) buyW[buyIndex] = 0;
+        sellW[sellIndex] = 0;
       }
       if (matched) {
         misses = 0;
       } else {
         misses++;
         // These cheapest buys couldn't pair profitably — drop the cheapest one and retry with the next mix
-        const dropIdx = buyPool.findIndex(({ i }) => i === buyGroup[0]);
-        if (dropIdx >= 0) buyPool.splice(dropIdx, 1);
+        const dropIndex = buyPool.findIndex(({ slotIndex }) => slotIndex === buyGroup[0]);
+        if (dropIndex >= 0) buyPool.splice(dropIndex, 1);
         else break;
       }
     }
     if (pairs) {
       notes.push(
-        `Arbitrage: ${pairs} buy/sell slot pair(s) accepted — spread beats fees + losses + ${k.min_buy_saving_sek_per_kwh} SEK/kWh margin`
+        `Arbitrage: ${pairs} buy/sell slot pair(s) accepted — spread beats fees + losses + ${knobs.min_buy_saving_sek_per_kwh} SEK/kWh margin`
       );
     }
   }
@@ -247,45 +256,59 @@ export function generatePlan(input: PlannerInput): PlanResult {
     acceptedSell,
     sellW,
     "sell",
-    k.min_window_minutes
+    knobs.min_window_minutes
   );
   if (droppedShort) {
-    notes.push(`Dropped ${droppedShort} sell window(s) shorter than ${k.min_window_minutes} min`);
-    for (const i of acceptedSell) {
-      if (!sellWindows.some(w => w.slotIndexes.includes(i))) sellW[i] = 0;
+    notes.push(`Dropped ${droppedShort} sell window(s) shorter than ${knobs.min_window_minutes} min`);
+    for (const slotIndex of acceptedSell) {
+      if (!sellWindows.some(window => window.slotIndexes.includes(slotIndex))) sellW[slotIndex] = 0;
     }
     current = simulate(input, slots, sellW, buyW, tailSpot);
   }
 
-  const { windows: buyWindows } = mergeAcceptedSlots(slots, acceptedBuy, buyW, "buy", k.min_window_minutes);
+  const { windows: buyWindows } = mergeAcceptedSlots(slots, acceptedBuy, buyW, "buy", knobs.min_window_minutes);
 
   // ---- Package result ----
-  const spotsAll = pricedSlots.map(s => s.spot!).sort((a, b) => a - b);
-  const percentileOf = (v: number) => Math.round((spotsAll.filter(x => x <= v).length / spotsAll.length) * 100);
+  const spotsAll = pricedSlots.map(slot => slot.spot!).sort((a, b) => a - b);
+  const percentileOf = (value: number) =>
+    Math.round((spotsAll.filter(spot => spot <= value).length / spotsAll.length) * 100);
 
-  const toPlanned = (w: MergedWindow): PlannedWindow => {
-    const spots = w.slotIndexes.map(i => slots[i].spot!).filter(v => v !== undefined);
-    const avgSpot = spots.reduce((a, b) => a + b, 0) / Math.max(spots.length, 1);
-    const socBefore = current.socAfterSlot[Math.max(0, w.slotIndexes[0] - 1)] ?? (input.socPercent / 100) * cap;
-    const socAfter = current.socAfterSlot[w.slotIndexes[w.slotIndexes.length - 1]];
+  const toPlanned = (mergedWindow: MergedWindow): PlannedWindow => {
+    const spots = mergedWindow.slotIndexes.map(slotIndex => slots[slotIndex].spot!).filter(spot => spot !== undefined);
+    const avgSpot = spots.reduce((sum, spot) => sum + spot, 0) / Math.max(spots.length, 1);
+    const socBefore =
+      current.socAfterSlot[Math.max(0, mergedWindow.slotIndexes[0] - 1)] ?? (input.socPercent / 100) * cap;
+    const socAfter = current.socAfterSlot[mergedWindow.slotIndexes[mergedWindow.slotIndexes.length - 1]];
     let expectedKwh: number;
-    if (w.kind === "sell") {
-      expectedKwh = w.slotIndexes.reduce((sum, i) => {
-        const s = slots[i];
-        const exportW = Math.max(0, Math.min(w.watts, k.inverter_max_ac_output_watts - s.houseW));
-        return sum + (exportW * s.durationH) / 1000;
+    if (mergedWindow.kind === "sell") {
+      expectedKwh = mergedWindow.slotIndexes.reduce((sum, slotIndex) => {
+        const slot = slots[slotIndex];
+        const exportW = Math.max(0, Math.min(mergedWindow.watts, knobs.inverter_max_ac_output_watts - slot.houseW));
+        return sum + (exportW * slot.durationH) / 1000;
       }, 0);
     } else {
-      expectedKwh = w.slotIndexes.reduce((sum, i) => sum + (w.watts * slots[i].durationH) / 1000, 0);
+      expectedKwh = mergedWindow.slotIndexes.reduce(
+        (sum, slotIndex) => sum + (mergedWindow.watts * slots[slotIndex].durationH) / 1000,
+        0
+      );
     }
-    const isArbitrage = w.kind === "buy" && w.slotIndexes.some(i => arbitrageBuySlots.has(i));
+    const isArbitrage =
+      mergedWindow.kind === "buy" && mergedWindow.slotIndexes.some(slotIndex => arbitrageBuySlots.has(slotIndex));
     const reason =
-      w.kind === "sell"
+      mergedWindow.kind === "sell"
         ? `spot avg ${avgSpot.toFixed(2)} SEK/kWh (P${percentileOf(avgSpot)} of horizon), ~${expectedKwh.toFixed(0)} kWh, SOC ${Math.round((socBefore / cap) * 100)}%→${Math.round((socAfter / cap) * 100)}%`
         : isArbitrage
           ? `arbitrage: buying ~${expectedKwh.toFixed(0)} kWh at ${avgSpot.toFixed(2)} SEK/kWh (P${percentileOf(avgSpot)}) to re-sell at the later price peak`
           : `cheap spot avg ${avgSpot.toFixed(2)} SEK/kWh (P${percentileOf(avgSpot)}), pre-buying ~${expectedKwh.toFixed(0)} kWh to avoid pricier unavoidable import`;
-    return { startMs: w.startMs, endMs: w.endMs, watts: w.watts, kind: w.kind, reason, expectedKwh, avgSpot };
+    return {
+      startMs: mergedWindow.startMs,
+      endMs: mergedWindow.endMs,
+      watts: mergedWindow.watts,
+      kind: mergedWindow.kind,
+      reason,
+      expectedKwh,
+      avgSpot,
+    };
   };
 
   const sells = sellWindows.map(toPlanned);
@@ -299,7 +322,7 @@ export function generatePlan(input: PlannerInput): PlanResult {
   notes.push(
     `Horizon ${new Date(Math.max(input.nowMs, pricedSlots[0].startMs)).toISOString()} → ${new Date(pricedSlots[pricedSlots.length - 1].endMs).toISOString()} (+${input.constraintTailHours}h reserve tail)`
   );
-  if (k.extra_reserve_kwh > 0) notes.push(`User extra reserve of ${k.extra_reserve_kwh} kWh respected`);
+  if (knobs.extra_reserve_kwh > 0) notes.push(`User extra reserve of ${knobs.extra_reserve_kwh} kWh respected`);
 
   const projection: PlanProjection = {
     startSocPercent: input.socPercent,
@@ -337,27 +360,27 @@ export function projectWithFixedWindows(input: PlannerInput): {
   revenueSek: number;
 } {
   const slots = buildSlots(input);
-  const pricedSlots = slots.filter(s => s.spot !== undefined);
+  const pricedSlots = slots.filter(slot => slot.spot !== undefined);
   const lastDaySpots = pricedSlots
     .slice(-96)
-    .map(s => s.spot!)
+    .map(slot => slot.spot!)
     .sort((a, b) => a - b);
   const tailSpot = lastDaySpots[Math.floor(lastDaySpots.length / 2)] ?? 0.5;
-  const r = simulate(input, slots, new Array(slots.length).fill(0), new Array(slots.length).fill(0), tailSpot);
+  const result = simulate(input, slots, new Array(slots.length).fill(0), new Array(slots.length).fill(0), tailSpot);
   return {
-    violationWh: r.violationWh,
-    minSocPercent: Math.round((r.minSocWh / input.capacityWh) * 1000) / 10,
-    minSocAt: new Date(r.minSocMs).toISOString(),
-    unavoidableImportKwh: Math.round(r.importWh / 100) / 10,
-    endSocPercent: Math.round((r.endSocWh / input.capacityWh) * 1000) / 10,
-    revenueSek: Math.round(r.revenueSek * 10) / 10,
+    violationWh: result.violationWh,
+    minSocPercent: Math.round((result.minSocWh / input.capacityWh) * 1000) / 10,
+    minSocAt: new Date(result.minSocMs).toISOString(),
+    unavoidableImportKwh: Math.round(result.importWh / 100) / 10,
+    endSocPercent: Math.round((result.endSocWh / input.capacityWh) * 1000) / 10,
+    revenueSek: Math.round(result.revenueSek * 10) / 10,
   };
 }
 
 function windowPowerAt(windows: FixedWindow[], startMs: number, endMs: number): number {
   let max = 0;
-  for (const w of windows) {
-    if (w.startMs < endMs && w.endMs > startMs) max = Math.max(max, w.watts);
+  for (const window of windows) {
+    if (window.startMs < endMs && window.endMs > startMs) max = Math.max(max, window.watts);
   }
   return max;
 }
@@ -365,7 +388,7 @@ function windowPowerAt(windows: FixedWindow[], startMs: number, endMs: number): 
 function buildSlots(input: PlannerInput): Slot[] {
   const { prices, nowMs, constraintTailHours, houseLoadWattsAt, fixedSells, fixedBuys } = input;
   const slots: Slot[] = [];
-  const relevantPrices = prices.filter(p => p.startMs + SLOT_MS > nowMs).sort((a, b) => a.startMs - b.startMs);
+  const relevantPrices = prices.filter(price => price.startMs + SLOT_MS > nowMs).sort((a, b) => a.startMs - b.startMs);
   const pricedEndMs = relevantPrices.length ? relevantPrices[relevantPrices.length - 1].startMs + SLOT_MS : nowMs;
   const tailEndMs = pricedEndMs + constraintTailHours * 3600 * 1000;
 
@@ -387,8 +410,10 @@ function buildSlots(input: PlannerInput): Slot[] {
     });
   };
 
-  for (const p of relevantPrices) pushSlot(p.startMs, p.spot);
-  for (let t = pricedEndMs; t < tailEndMs; t += SLOT_MS) pushSlot(t, undefined);
+  for (const price of relevantPrices) pushSlot(price.startMs, price.spot);
+  for (let slotStartMs = pricedEndMs; slotStartMs < tailEndMs; slotStartMs += SLOT_MS) {
+    pushSlot(slotStartMs, undefined);
+  }
   return slots;
 }
 


### PR DESCRIPTION
The two review comments on #30 (\"Not a real variable name?\" / \"why did you do this variable name??\") pointed at `const k = input.knobs` and `const s = slots[i]` in simulate.ts — which got renamed during that merge, but the same aliases I wrote lived on in planner.ts. Rename-only sweep to match the simulate.ts conventions: `knobs`, `{ slot, slotIndex }` candidate pairs, `result`, `window`, `price`, `mergedWindow`, `buyIndex`/`sellIndex`. Bare numeric loop counters (`i`, `j`, `idx`) stay, matching the precedent set in the simulate.ts rename. CLAUDE.md's descriptive-names rule names `k` explicitly — lesson taken: the rule beats \"match surrounding legacy style\".

No behavior change: typecheck clean, all selftest scenarios pass with identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gnx4sUB71SzTnG5iP5dcZN